### PR TITLE
Add responsive layout showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Web Native Showcase
 
-This repository is a playground for showcasing web capabilities using **HTML**, **CSS**, and **JavaScript**.  The goal is to collect small, self‑contained examples that demonstrate native browser features without relying on external frameworks.
+This repository is a playground for showcasing web capabilities using **HTML**, **CSS**, and **JavaScript**. The goal is to collect small, self‑contained examples that demonstrate native browser features without relying on external frameworks.
+
+## Showcases
+
+- [Responsive layout with header, footer, and side navigation](responsive-layout/)
 
 ## Planned Showcases
 
 The following ideas are candidates for future demonstrations:
 
-- Responsive layout with header, footer, and side navigation.
 - Interactive image gallery with lightbox effect.
 - Form validation using HTML5 attributes and JavaScript enhancements.
 - CSS animations and transitions triggered by user interaction.
@@ -15,5 +18,4 @@ The following ideas are candidates for future demonstrations:
 
 ## Contributing
 
-Ideas for additional showcases are welcome!  Open an issue or submit a pull request with a new example, and update this list to keep track of progress.
-
+Ideas for additional showcases are welcome! Open an issue or submit a pull request with a new example, and update this list to keep track of progress.

--- a/responsive-layout/index.html
+++ b/responsive-layout/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Responsive Layout Example</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
+    <h1>Web Native Showcase</h1>
+  </header>
+
+  <nav id="side-nav" class="side-nav" aria-label="Side navigation">
+    <ul>
+      <li><a href="#home">Home</a></li>
+      <li><a href="#about">About</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ul>
+  </nav>
+
+  <main class="content">
+    <section id="home">
+      <h2>Welcome</h2>
+      <p>This layout adjusts to your screen size. Resize the browser window to see the responsiveness in action.</p>
+    </section>
+    <section id="about">
+      <h2>About</h2>
+      <p>The side navigation collapses into a hamburger menu on smaller screens.</p>
+    </section>
+    <section id="contact">
+      <h2>Contact</h2>
+      <p>Pure HTML, CSS, and JavaScript—no frameworks required.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2024 Web Native Showcase</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/responsive-layout/script.js
+++ b/responsive-layout/script.js
@@ -1,0 +1,3 @@
+document.getElementById('menu-toggle').addEventListener('click', function () {
+  document.getElementById('side-nav').classList.toggle('open');
+});

--- a/responsive-layout/styles.css
+++ b/responsive-layout/styles.css
@@ -1,0 +1,95 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "header header"
+    "sidenav content"
+    "footer footer";
+  min-height: 100vh;
+}
+
+.site-header {
+  grid-area: header;
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.side-nav {
+  grid-area: sidenav;
+  background-color: #f4f4f4;
+  padding: 1rem;
+}
+
+.side-nav ul {
+  list-style: none;
+}
+
+.side-nav a {
+  display: block;
+  padding: 0.5rem 0;
+  color: #333;
+  text-decoration: none;
+}
+
+.content {
+  grid-area: content;
+  padding: 1rem;
+}
+
+.site-footer {
+  grid-area: footer;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "header"
+      "content"
+      "footer";
+  }
+
+  .side-nav {
+    position: fixed;
+    top: 0;
+    left: -220px;
+    width: 200px;
+    height: 100%;
+    transition: left 0.3s ease;
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.3);
+  }
+
+  .side-nav.open {
+    left: 0;
+    background-color: #f4f4f4;
+  }
+
+  .menu-toggle {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary
- Add responsive layout example with header, footer, and collapsible side navigation using HTML, CSS Grid, and JavaScript.
- Update README to link to the new showcase and maintain list of upcoming examples.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d3e2a9688333bdf20b6172dd796a