### PR TITLE
Add HTML5 form validation showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This repository is a playground for showcasing web capabilities using **HTML**, 
 
 - [Responsive layout with header, footer, and side navigation](responsive-layout/)
 - [Interactive image gallery with lightbox effect](image-gallery/)
+- [Sign‑up form with built‑in and custom validation](form-validation/)
 
 ## Planned Showcases
 
 The following ideas are candidates for future demonstrations:
-- Form validation using HTML5 attributes and JavaScript enhancements.
 - CSS animations and transitions triggered by user interaction.
 - Fetch API example retrieving and displaying remote data.
 - Simple drag‑and‑drop interface.

--- a/form-validation/index.html
+++ b/form-validation/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Form Validation Showcase</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Sign Up</h1>
+  <form id="signup-form" novalidate>
+    <label for="username">Username
+      <input type="text" id="username" name="username" required minlength="3" aria-describedby="username-help" />
+    </label>
+    <small id="username-help">At least 3 characters</small>
+
+    <label for="email">Email
+      <input type="email" id="email" name="email" required />
+    </label>
+
+    <label for="password">Password
+      <input type="password" id="password" name="password" required minlength="8"
+        pattern="(?=.*[A-Z])(?=.*\\d)[A-Za-z\\d]{8,}" />
+    </label>
+    <small>Use 8+ characters with an uppercase letter and a number.</small>
+
+    <label for="confirmPassword">Confirm Password
+      <input type="password" id="confirmPassword" name="confirmPassword" required />
+    </label>
+
+    <button type="submit">Register</button>
+  </form>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/form-validation/script.js
+++ b/form-validation/script.js
@@ -1,0 +1,22 @@
+const form = document.getElementById('signup-form');
+const password = document.getElementById('password');
+const confirmPassword = document.getElementById('confirmPassword');
+
+function validatePasswordMatch() {
+  if (confirmPassword.value && confirmPassword.value !== password.value) {
+    confirmPassword.setCustomValidity('Passwords must match');
+  } else {
+    confirmPassword.setCustomValidity('');
+  }
+}
+
+password.addEventListener('input', validatePasswordMatch);
+confirmPassword.addEventListener('input', validatePasswordMatch);
+
+form.addEventListener('submit', (e) => {
+  validatePasswordMatch();
+  if (!form.checkValidity()) {
+    e.preventDefault();
+    form.reportValidity();
+  }
+});

--- a/form-validation/styles.css
+++ b/form-validation/styles.css
@@ -1,0 +1,51 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 2rem;
+  background: #f8f9fa;
+}
+
+form {
+  max-width: 400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+input:invalid {
+  border-color: #e63946;
+}
+
+input:valid {
+  border-color: #2a9d8f;
+}
+
+small {
+  color: #555;
+}
+
+button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #457b9d;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #1d3557;
+}


### PR DESCRIPTION
## Summary
- add sign-up form demonstrating HTML5 validation attributes and JS enhancements
- style inputs to highlight validity
- document new example in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d5ece73c8333a35ae9bfefb0c92d