### PR TITLE
Add animation, fetch, and drag-and-drop showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ This repository is a playground for showcasing web capabilities using **HTML**, 
 - [Responsive layout with header, footer, and side navigation](responsive-layout/)
 - [Interactive image gallery with lightbox effect](image-gallery/)
 - [Sign‑up form with built‑in and custom validation](form-validation/)
+- [CSS animations and transitions triggered by user interaction](css-animations/)
+- [Fetch API example retrieving GitHub user data](github-fetch/)
+- [Simple drag‑and‑drop interface](drag-and-drop/)
 
 ## Planned Showcases
 
 The following ideas are candidates for future demonstrations:
-- CSS animations and transitions triggered by user interaction.
-- Fetch API example retrieving and displaying remote data.
-- Simple drag‑and‑drop interface.
+- *(Add your idea here!)*
 
 ## Contributing
 

--- a/css-animations/index.html
+++ b/css-animations/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Animations Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>CSS Animations and Transitions</h1>
+  <button id="animateBtn">Animate Box</button>
+  <div id="box" class="box"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/css-animations/script.js
+++ b/css-animations/script.js
@@ -1,0 +1,8 @@
+const box = document.getElementById('box');
+const button = document.getElementById('animateBtn');
+
+button.addEventListener('click', () => {
+  box.classList.remove('spin');
+  void box.offsetWidth; // trigger reflow to restart animation
+  box.classList.add('spin');
+});

--- a/css-animations/styles.css
+++ b/css-animations/styles.css
@@ -1,0 +1,43 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+  background-color: #fafafa;
+  color: #333;
+  text-align: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.box {
+  width: 100px;
+  height: 100px;
+  margin: 2rem auto;
+  background: #3498db;
+  border-radius: 8px;
+  transition: transform 0.5s ease, background-color 0.5s ease;
+}
+
+.box:hover {
+  background: #2980b9;
+  transform: scale(1.1);
+}
+
+.box.spin {
+  animation: spin 1s linear;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/drag-and-drop/index.html
+++ b/drag-and-drop/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drag and Drop Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Drag and Drop</h1>
+  <div class="container">
+    <div class="items">
+      <div class="draggable" draggable="true" id="item1" style="background:#e74c3c;"></div>
+      <div class="draggable" draggable="true" id="item2" style="background:#2ecc71;"></div>
+      <div class="draggable" draggable="true" id="item3" style="background:#f1c40f;"></div>
+    </div>
+    <div class="dropzone" id="dropzone">Drop here</div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/drag-and-drop/script.js
+++ b/drag-and-drop/script.js
@@ -1,0 +1,25 @@
+const draggables = document.querySelectorAll('.draggable');
+const dropzone = document.getElementById('dropzone');
+
+draggables.forEach((item) => {
+  item.addEventListener('dragstart', (e) => {
+    e.dataTransfer.setData('text/plain', item.id);
+  });
+});
+
+dropzone.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  dropzone.classList.add('hover');
+});
+
+dropzone.addEventListener('dragleave', () => {
+  dropzone.classList.remove('hover');
+});
+
+dropzone.addEventListener('drop', (e) => {
+  e.preventDefault();
+  dropzone.classList.remove('hover');
+  const id = e.dataTransfer.getData('text/plain');
+  const dragged = document.getElementById(id);
+  dropzone.appendChild(dragged);
+});

--- a/drag-and-drop/styles.css
+++ b/drag-and-drop/styles.css
@@ -1,0 +1,50 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+  background-color: #fafafa;
+  color: #333;
+}
+
+h1 {
+  text-align: center;
+}
+
+.container {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.draggable {
+  width: 60px;
+  height: 60px;
+  border-radius: 4px;
+  cursor: grab;
+}
+
+.dropzone {
+  width: 200px;
+  height: 200px;
+  border: 2px dashed #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border-radius: 4px;
+}
+
+.dropzone.hover {
+  border-color: #3498db;
+  background: #ecf5ff;
+}

--- a/github-fetch/index.html
+++ b/github-fetch/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GitHub User Fetch</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>GitHub User Lookup</h1>
+  <form id="user-form">
+    <input type="text" id="username" placeholder="Enter GitHub username" required />
+    <button type="submit">Fetch</button>
+  </form>
+  <div id="result" class="result"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/github-fetch/script.js
+++ b/github-fetch/script.js
@@ -1,0 +1,25 @@
+const form = document.getElementById('user-form');
+const result = document.getElementById('result');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  if (!username) return;
+  result.textContent = 'Loading...';
+  try {
+    const response = await fetch(`https://api.github.com/users/${username}`);
+    if (!response.ok) {
+      result.textContent = 'User not found';
+      return;
+    }
+    const data = await response.json();
+    result.innerHTML = `
+      <img src="${data.avatar_url}" alt="${data.login}'s avatar" />
+      <h2>${data.login}</h2>
+      ${data.name ? `<p>${data.name}</p>` : ''}
+      <p>Public repos: ${data.public_repos}</p>
+    `;
+  } catch (err) {
+    result.textContent = 'Error fetching data';
+  }
+});

--- a/github-fetch/styles.css
+++ b/github-fetch/styles.css
@@ -1,0 +1,33 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+  background-color: #fafafa;
+  color: #333;
+  text-align: center;
+}
+
+form {
+  margin-bottom: 1rem;
+}
+
+input {
+  padding: 0.5rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.result img {
+  width: 100px;
+  border-radius: 50%;
+}
+
+.result {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add CSS animation demo with hover transitions and button-triggered spin effect
- introduce GitHub user lookup using the Fetch API
- create basic drag-and-drop example for moving elements into a drop zone

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d73e14f08333b8ccf3332f2f93f2