### PR TITLE
Add dark mode toggle and custom context menu examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This repository is a playground for showcasing web capabilities using **HTML**, 
 - [Fetch API example retrieving GitHub user data](github-fetch/)
 - [Simple drag‑and‑drop interface](drag-and-drop/)
 - [Infinite scroll content loading using Intersection Observer API](infinite-scroll/)
+- [Dark mode toggle with prefers-color-scheme](dark-mode-toggle/)
+- [Custom context menu](custom-context-menu/)
 
 ## Planned Showcases
 
 
-	•	Dark mode / light mode toggle with prefers-color-scheme support
-	•	Custom context menu with JavaScript event handling
 	•	File upload with live preview (images, text, PDFs)
 	•	Geolocation API to display user’s current location on a map
 	•	Web Speech API for text-to-speech and speech-to-text

--- a/custom-context-menu/index.html
+++ b/custom-context-menu/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Custom Context Menu</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Custom Context Menu</h1>
+  <p>Right-click anywhere on this page to see the custom context menu.</p>
+  <ul id="context-menu" class="menu hidden" role="menu">
+    <li class="menu-item" role="menuitem" data-action="greet">Say Hello</li>
+    <li class="menu-item" role="menuitem" data-action="time">Show Time</li>
+  </ul>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/custom-context-menu/script.js
+++ b/custom-context-menu/script.js
@@ -1,0 +1,23 @@
+const menu = document.getElementById('context-menu');
+
+document.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  menu.style.top = `${e.clientY}px`;
+  menu.style.left = `${e.clientX}px`;
+  menu.classList.remove('hidden');
+});
+
+document.addEventListener('click', () => {
+  menu.classList.add('hidden');
+});
+
+menu.addEventListener('click', (e) => {
+  if (e.target.matches('.menu-item')) {
+    const action = e.target.dataset.action;
+    if (action === 'greet') {
+      alert('Hello!');
+    } else if (action === 'time') {
+      alert(new Date().toLocaleTimeString());
+    }
+  }
+});

--- a/custom-context-menu/styles.css
+++ b/custom-context-menu/styles.css
@@ -1,0 +1,33 @@
+body {
+  font-family: sans-serif;
+  height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.menu {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem 0;
+  list-style: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  min-width: 150px;
+  z-index: 1000;
+}
+
+.menu.hidden {
+  display: none;
+}
+
+.menu-item {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.menu-item:hover {
+  background: #f0f0f0;
+}

--- a/dark-mode-toggle/index.html
+++ b/dark-mode-toggle/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dark Mode Toggle</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="theme-toggle" aria-label="Toggle dark mode">Toggle Theme</button>
+  <h1>Dark Mode Example</h1>
+  <p>This example demonstrates a light/dark theme toggle that respects the user's system preference.</p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/dark-mode-toggle/script.js
+++ b/dark-mode-toggle/script.js
@@ -1,0 +1,32 @@
+const toggleButton = document.getElementById('theme-toggle');
+const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+function setTheme(theme) {
+  document.body.classList.remove('light', 'dark');
+  document.body.classList.add(theme);
+  localStorage.setItem('theme', theme);
+}
+
+function initTheme() {
+  const stored = localStorage.getItem('theme');
+  if (stored) {
+    setTheme(stored);
+  } else if (prefersDarkScheme.matches) {
+    document.body.classList.add('dark');
+  } else {
+    document.body.classList.add('light');
+  }
+}
+
+toggleButton.addEventListener('click', () => {
+  const isDark = document.body.classList.contains('dark');
+  setTheme(isDark ? 'light' : 'dark');
+});
+
+prefersDarkScheme.addEventListener('change', (e) => {
+  if (!localStorage.getItem('theme')) {
+    setTheme(e.matches ? 'dark' : 'light');
+  }
+});
+
+initTheme();

--- a/dark-mode-toggle/styles.css
+++ b/dark-mode-toggle/styles.css
@@ -1,0 +1,40 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #121212;
+    --text-color: #e4e4e4;
+  }
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: sans-serif;
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+body.dark {
+  --bg-color: #121212;
+  --text-color: #e4e4e4;
+}
+
+body.light {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}


### PR DESCRIPTION
## Summary
- Add dark mode/light mode toggle honoring `prefers-color-scheme`
- Implement custom right-click menu with JavaScript event handling
- Update README to list new showcases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689600d3e4248333a34d898ec54a2b95