### PR TITLE
Add file upload preview and geolocation demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ This repository is a playground for showcasing web capabilities using **HTML**, 
 - [Fetch API example retrieving GitHub user data](github-fetch/)
 - [Simple drag‑and‑drop interface](drag-and-drop/)
 - [Infinite scroll content loading using Intersection Observer API](infinite-scroll/)
+- [File upload with live preview (images, text, PDFs)](file-upload-preview/)
+- [Geolocation API to display user’s current location on a map](geolocation/)
 
 ## Planned Showcases
 
 
 	•	Dark mode / light mode toggle with prefers-color-scheme support
 	•	Custom context menu with JavaScript event handling
-	•	File upload with live preview (images, text, PDFs)
-	•	Geolocation API to display user’s current location on a map
 	•	Web Speech API for text-to-speech and speech-to-text
 	•	Offline caching using Service Workers
 	•	Clipboard API for copy and paste functionality

--- a/file-upload-preview/index.html
+++ b/file-upload-preview/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>File Upload Preview</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>File Upload with Live Preview</h1>
+  <input type="file" id="fileInput" accept="image/*,.txt,application/pdf" />
+  <div id="preview"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/file-upload-preview/script.js
+++ b/file-upload-preview/script.js
@@ -1,0 +1,34 @@
+const input = document.getElementById('fileInput');
+const preview = document.getElementById('preview');
+
+input.addEventListener('change', () => {
+  preview.innerHTML = '';
+  const file = input.files[0];
+  if (!file) return;
+
+  const type = file.type;
+
+  if (type.startsWith('image/')) {
+    const img = document.createElement('img');
+    img.src = URL.createObjectURL(file);
+    img.onload = () => URL.revokeObjectURL(img.src);
+    preview.appendChild(img);
+  } else if (type === 'application/pdf') {
+    const embed = document.createElement('embed');
+    embed.src = URL.createObjectURL(file);
+    embed.type = 'application/pdf';
+    embed.width = '100%';
+    embed.height = '500px';
+    preview.appendChild(embed);
+  } else if (type.startsWith('text/')) {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const pre = document.createElement('pre');
+      pre.textContent = e.target.result;
+      preview.appendChild(pre);
+    };
+    reader.readAsText(file);
+  } else {
+    preview.textContent = 'Unsupported file type';
+  }
+});

--- a/file-upload-preview/styles.css
+++ b/file-upload-preview/styles.css
@@ -1,0 +1,18 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+}
+
+#preview {
+  margin-top: 20px;
+}
+
+#preview img,
+#preview embed,
+#preview pre {
+  max-width: 100%;
+  max-height: 500px;
+  border: 1px solid #ccc;
+  padding: 10px;
+  box-sizing: border-box;
+}

--- a/geolocation/index.html
+++ b/geolocation/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Geolocation Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Your Current Location</h1>
+  <p id="status">Locating…</p>
+  <div id="map"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/geolocation/script.js
+++ b/geolocation/script.js
@@ -1,0 +1,24 @@
+const status = document.getElementById('status');
+const map = document.getElementById('map');
+
+function success(position) {
+  const { latitude, longitude } = position.coords;
+  status.textContent = `Latitude: ${latitude.toFixed(4)}, Longitude: ${longitude.toFixed(4)}`;
+  const iframe = document.createElement('iframe');
+  iframe.src = `https://maps.google.com/maps?q=${latitude},${longitude}&z=15&output=embed`;
+  iframe.width = '100%';
+  iframe.height = '100%';
+  iframe.style.border = '0';
+  map.innerHTML = '';
+  map.appendChild(iframe);
+}
+
+function error() {
+  status.textContent = 'Unable to retrieve your location';
+}
+
+if ('geolocation' in navigator) {
+  navigator.geolocation.getCurrentPosition(success, error);
+} else {
+  status.textContent = 'Geolocation is not supported by your browser';
+}

--- a/geolocation/styles.css
+++ b/geolocation/styles.css
@@ -1,0 +1,11 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+}
+
+#map {
+  margin-top: 20px;
+  width: 100%;
+  height: 450px;
+  border: 1px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- add file upload with live preview for images, text files, and PDFs
- implement geolocation API demo showing the user’s location on an embedded map
- document new demos in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689600dc49788333882d84e669da9953