### PR TITLE
Add Clipboard and Web Notifications examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository is a playground for showcasing web capabilities using **HTML**, 
 - [Fetch API example retrieving GitHub user data](github-fetch/)
 - [Simple drag‑and‑drop interface](drag-and-drop/)
 - [Infinite scroll content loading using Intersection Observer API](infinite-scroll/)
+- [Clipboard copy and paste demo](clipboard/)
+- [Web Notifications with permission request](web-notifications/)
 
 ## Planned Showcases
 
@@ -21,8 +23,6 @@ This repository is a playground for showcasing web capabilities using **HTML**, 
 	•	Geolocation API to display user’s current location on a map
 	•	Web Speech API for text-to-speech and speech-to-text
 	•	Offline caching using Service Workers
-	•	Clipboard API for copy and paste functionality
-	•	Web Notifications API with permission handling
 	•	CSS grid-based responsive image masonry layout
 	•	Keyboard shortcut handling for faster navigation
 	•	LocalStorage and SessionStorage for saving user preferences

--- a/clipboard/index.html
+++ b/clipboard/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Clipboard Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Clipboard API</h1>
+  <textarea id="source" rows="4" placeholder="Type something here..."></textarea>
+  <div class="buttons">
+    <button id="copy">Copy</button>
+    <button id="paste">Paste</button>
+  </div>
+  <textarea id="destination" rows="4" placeholder="Paste result appears here..."></textarea>
+  <p id="status"></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/clipboard/script.js
+++ b/clipboard/script.js
@@ -5,6 +5,10 @@ const destination = document.getElementById('destination');
 const status = document.getElementById('status');
 
 copyBtn.addEventListener('click', async () => {
+  if (!navigator.clipboard) {
+    status.textContent = 'Clipboard API not supported in this browser.';
+    return;
+  }
   try {
     await navigator.clipboard.writeText(source.value);
     status.textContent = 'Copied to clipboard!';

--- a/clipboard/script.js
+++ b/clipboard/script.js
@@ -14,7 +14,19 @@ copyBtn.addEventListener('click', async () => {
 });
 
 pasteBtn.addEventListener('click', async () => {
+  if (!navigator.clipboard) {
+    status.textContent = 'Clipboard API not supported.';
+    return;
+  }
   try {
+    // Check for clipboard-read permission if Permissions API is available
+    if (navigator.permissions) {
+      const permissionStatus = await navigator.permissions.query({ name: 'clipboard-read' });
+      if (permissionStatus.state !== 'granted' && permissionStatus.state !== 'prompt') {
+        status.textContent = 'Clipboard read permission denied.';
+        return;
+      }
+    }
     const text = await navigator.clipboard.readText();
     destination.value = text;
     status.textContent = 'Pasted from clipboard!';

--- a/clipboard/script.js
+++ b/clipboard/script.js
@@ -1,0 +1,24 @@
+const copyBtn = document.getElementById('copy');
+const pasteBtn = document.getElementById('paste');
+const source = document.getElementById('source');
+const destination = document.getElementById('destination');
+const status = document.getElementById('status');
+
+copyBtn.addEventListener('click', async () => {
+  try {
+    await navigator.clipboard.writeText(source.value);
+    status.textContent = 'Copied to clipboard!';
+  } catch (err) {
+    status.textContent = 'Copy failed.';
+  }
+});
+
+pasteBtn.addEventListener('click', async () => {
+  try {
+    const text = await navigator.clipboard.readText();
+    destination.value = text;
+    status.textContent = 'Pasted from clipboard!';
+  } catch (err) {
+    status.textContent = 'Paste failed.';
+  }
+});

--- a/clipboard/styles.css
+++ b/clipboard/styles.css
@@ -1,0 +1,36 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+  background-color: #fafafa;
+  color: #333;
+}
+
+h1 {
+  text-align: center;
+}
+
+textarea {
+  width: 100%;
+  max-width: 400px;
+  display: block;
+  margin: 0.5rem auto;
+}
+
+.buttons {
+  text-align: center;
+  margin: 0.5rem 0;
+}
+
+button {
+  margin: 0 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+#status {
+  text-align: center;
+  margin-top: 0.5rem;
+}

--- a/web-notifications/index.html
+++ b/web-notifications/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Web Notifications Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Web Notifications</h1>
+  <button id="notify">Show Notification</button>
+  <p id="status"></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/web-notifications/script.js
+++ b/web-notifications/script.js
@@ -18,7 +18,14 @@ button.addEventListener('click', async () => {
   }
 
   if (permission === 'granted') {
-    new Notification('Hello from the Web!');
+    const notification = new Notification('Hello from the Web!', {
+      body: 'This is a sample notification body.',
+      icon: 'https://www.example.com/icon.png'
+    });
+    notification.onclick = () => {
+      window.focus();
+      status.textContent = 'Notification clicked!';
+    };
     status.textContent = 'Notification displayed.';
   } else {
     status.textContent = 'Notification permission denied.';

--- a/web-notifications/script.js
+++ b/web-notifications/script.js
@@ -1,0 +1,26 @@
+const button = document.getElementById('notify');
+const status = document.getElementById('status');
+
+button.addEventListener('click', async () => {
+  if (!('Notification' in window)) {
+    status.textContent = 'Notifications are not supported in this browser.';
+    return;
+  }
+
+  let permission = Notification.permission;
+  if (permission === 'default') {
+    try {
+      permission = await Notification.requestPermission();
+    } catch (err) {
+      status.textContent = 'Permission request failed.';
+      return;
+    }
+  }
+
+  if (permission === 'granted') {
+    new Notification('Hello from the Web!');
+    status.textContent = 'Notification displayed.';
+  } else {
+    status.textContent = 'Notification permission denied.';
+  }
+});

--- a/web-notifications/styles.css
+++ b/web-notifications/styles.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+  background-color: #fafafa;
+  color: #333;
+  text-align: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  margin-top: 1rem;
+}
+
+#status {
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- showcase clipboard copy & paste using the Clipboard API
- add Web Notifications demo with runtime permission handling
- document new demos and update planned list

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689600f249d48333af3338624b949fe6