### PR TITLE
Add implementations for planned showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ This repository is a playground for showcasing web capabilities using **HTML**, 
 - [Geolocation API to display user’s current location on a map](geolocation/)
 - [Dark mode toggle with prefers-color-scheme](dark-mode-toggle/)
 - [Custom context menu](custom-context-menu/)
+- [CSS grid-based responsive masonry image layout](css-grid-masonry/)
+- [Keyboard shortcut navigation](keyboard-shortcuts/)
+- [Save preferences with LocalStorage and SessionStorage](storage-preferences/)
+- [Progress bar and loading spinner](progress-loading/)
+- [Canvas drawing app with touch and mouse support](canvas-drawing/)
+- [Web Animations API scripted animations](web-animations/)
+- [Form autosave and restore from localStorage](form-autosave/)
+- [Custom video player with speed and captions](video-player/)
+- [CSS clip-path creative shapes and hover effects](clip-path/)
+- [Interactive Canvas chart](canvas-svg-charts/)
+- [Accessible modal dialog with focus trapping](modal-dialog/)
 
 ## Planned Showcases
 
-
-	•	CSS grid-based responsive image masonry layout
-	•	Keyboard shortcut handling for faster navigation
-	•	LocalStorage and SessionStorage for saving user preferences
-	•	Progress bar and loading spinner examples
-	•	HTML5 <canvas> drawing app with touch and mouse support
-	•	Web Animations API for scripted animations
-	•	Form autosave and restore from localStorage
-	•	Video player with custom controls (playback speed, captions)
-	•	CSS clip-path creative shapes and hover effects
-	•	Interactive charts using only Canvas or SVG (no libraries)
-	•	Accessible modal dialog with focus trapping
+None currently planned.
 
 ## Contributing
 

--- a/canvas-drawing/index.html
+++ b/canvas-drawing/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Canvas Drawing</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Canvas Drawing</h1>
+  <canvas id="canvas" width="500" height="400"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/canvas-drawing/script.js
+++ b/canvas-drawing/script.js
@@ -1,0 +1,47 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+let drawing = false;
+
+function getPos(e) {
+  const rect = canvas.getBoundingClientRect();
+  if (e.touches) {
+    return {
+      x: e.touches[0].clientX - rect.left,
+      y: e.touches[0].clientY - rect.top
+    };
+  }
+  return {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top
+  };
+}
+
+function start(e) {
+  drawing = true;
+  draw(e);
+}
+
+function end() {
+  drawing = false;
+  ctx.beginPath();
+}
+
+function draw(e) {
+  if (!drawing) return;
+  e.preventDefault();
+  const pos = getPos(e);
+  ctx.lineWidth = 4;
+  ctx.lineCap = 'round';
+  ctx.lineTo(pos.x, pos.y);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(pos.x, pos.y);
+}
+
+canvas.addEventListener('mousedown', start);
+canvas.addEventListener('touchstart', start);
+canvas.addEventListener('mousemove', draw);
+canvas.addEventListener('touchmove', draw);
+canvas.addEventListener('mouseup', end);
+canvas.addEventListener('mouseleave', end);
+canvas.addEventListener('touchend', end);

--- a/canvas-drawing/styles.css
+++ b/canvas-drawing/styles.css
@@ -1,0 +1,10 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+#canvas {
+  border: 1px solid #333;
+  touch-action: none;
+}

--- a/canvas-svg-charts/index.html
+++ b/canvas-svg-charts/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Canvas Chart</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Canvas Chart</h1>
+  <canvas id="chart" width="400" height="300"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/canvas-svg-charts/script.js
+++ b/canvas-svg-charts/script.js
@@ -1,0 +1,28 @@
+const canvas = document.getElementById('chart');
+const ctx = canvas.getContext('2d');
+const data = [4, 8, 15, 16, 23, 42];
+const barWidth = 40;
+const gap = 10;
+
+function draw(highlight = -1) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  data.forEach((v, i) => {
+    ctx.fillStyle = i === highlight ? 'orange' : 'steelblue';
+    const x = i * (barWidth + gap);
+    const y = canvas.height - v * 5;
+    ctx.fillRect(x, y, barWidth, v * 5);
+  });
+}
+
+draw();
+
+canvas.addEventListener('mousemove', e => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const index = Math.floor(x / (barWidth + gap));
+  if (index >= 0 && index < data.length) {
+    draw(index);
+  } else {
+    draw();
+  }
+});

--- a/canvas-svg-charts/styles.css
+++ b/canvas-svg-charts/styles.css
@@ -1,0 +1,9 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+canvas {
+  border: 1px solid #333;
+}

--- a/clip-path/index.html
+++ b/clip-path/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Clip Path Shapes</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Clip Path Shapes</h1>
+  <div class="shapes">
+    <div class="item circle" style="background-image:url('https://picsum.photos/200?1')"></div>
+    <div class="item polygon" style="background-image:url('https://picsum.photos/200?2')"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/clip-path/styles.css
+++ b/clip-path/styles.css
@@ -1,0 +1,33 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+.shapes {
+  display: flex;
+  gap: 20px;
+}
+
+.item {
+  width: 200px;
+  height: 200px;
+  background-size: cover;
+  transition: clip-path 0.5s;
+}
+
+.circle {
+  clip-path: circle(50%);
+}
+
+.circle:hover {
+  clip-path: ellipse(50% 40%);
+}
+
+.polygon {
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+}
+
+.polygon:hover {
+  clip-path: polygon(50% 0, 80% 100%, 20% 100%);
+}

--- a/css-grid-masonry/index.html
+++ b/css-grid-masonry/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Grid Masonry</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>CSS Grid Masonry</h1>
+  <div class="grid">
+    <div class="item"><img src="https://picsum.photos/300/200?1" alt="Random image 1" /></div>
+    <div class="item"><img src="https://picsum.photos/300/250?2" alt="Random image 2" /></div>
+    <div class="item"><img src="https://picsum.photos/300/180?3" alt="Random image 3" /></div>
+    <div class="item"><img src="https://picsum.photos/300/220?4" alt="Random image 4" /></div>
+    <div class="item"><img src="https://picsum.photos/300/260?5" alt="Random image 5" /></div>
+    <div class="item"><img src="https://picsum.photos/300/210?6" alt="Random image 6" /></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/css-grid-masonry/script.js
+++ b/css-grid-masonry/script.js
@@ -1,0 +1,12 @@
+const grid = document.querySelector('.grid');
+
+function resizeAll() {
+  grid.querySelectorAll('.item').forEach(item => {
+    const img = item.querySelector('img');
+    const rowSpan = Math.ceil((img.getBoundingClientRect().height + 10) / 10);
+    item.style.gridRowEnd = `span ${rowSpan}`;
+  });
+}
+
+window.addEventListener('load', resizeAll);
+window.addEventListener('resize', resizeAll);

--- a/css-grid-masonry/styles.css
+++ b/css-grid-masonry/styles.css
@@ -1,0 +1,21 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-auto-rows: 10px;
+  gap: 10px;
+}
+
+.item {
+  overflow: hidden;
+}
+
+.item img {
+  width: 100%;
+  display: block;
+}

--- a/form-autosave/index.html
+++ b/form-autosave/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Form Autosave</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Form Autosave</h1>
+  <form id="form">
+    <label>Name <input name="name" type="text" /></label>
+    <label>Message <textarea name="message"></textarea></label>
+  </form>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/form-autosave/script.js
+++ b/form-autosave/script.js
@@ -1,0 +1,20 @@
+const form = document.getElementById('form');
+const key = 'autosave';
+
+window.addEventListener('load', () => {
+  const saved = localStorage.getItem(key);
+  if (saved) {
+    const data = JSON.parse(saved);
+    Object.keys(data).forEach(k => {
+      if (form.elements[k]) form.elements[k].value = data[k];
+    });
+  }
+});
+
+form.addEventListener('input', () => {
+  const data = {};
+  Array.from(form.elements).forEach(el => {
+    if (el.name) data[el.name] = el.value;
+  });
+  localStorage.setItem(key, JSON.stringify(data));
+});

--- a/form-autosave/styles.css
+++ b/form-autosave/styles.css
@@ -1,0 +1,15 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+label {
+  display: block;
+  margin-bottom: 10px;
+}
+
+textarea {
+  width: 100%;
+  height: 100px;
+}

--- a/keyboard-shortcuts/index.html
+++ b/keyboard-shortcuts/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Keyboard Shortcuts Navigation</h1>
+  <p>Press <kbd>H</kbd>, <kbd>A</kbd>, or <kbd>C</kbd> to jump to sections.</p>
+  <nav>
+    <a href="#home">Home</a> |
+    <a href="#about">About</a> |
+    <a href="#contact">Contact</a>
+  </nav>
+  <section id="home"><h2>Home</h2><p>Welcome section.</p></section>
+  <section id="about"><h2>About</h2><p>About section.</p></section>
+  <section id="contact"><h2>Contact</h2><p>Contact section.</p></section>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/keyboard-shortcuts/script.js
+++ b/keyboard-shortcuts/script.js
@@ -1,0 +1,7 @@
+document.addEventListener('keydown', e => {
+  if (e.target !== document.body) return;
+  const key = e.key.toLowerCase();
+  if (key === 'h') location.hash = '#home';
+  else if (key === 'a') location.hash = '#about';
+  else if (key === 'c') location.hash = '#contact';
+});

--- a/keyboard-shortcuts/styles.css
+++ b/keyboard-shortcuts/styles.css
@@ -1,0 +1,10 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+section {
+  height: 60vh;
+  padding-top: 40px;
+}

--- a/modal-dialog/index.html
+++ b/modal-dialog/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Accessible Modal</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Accessible Modal</h1>
+  <button id="open">Open Modal</button>
+  <div id="modal" class="modal hidden" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="content">
+      <h2>Modal Title</h2>
+      <p>This modal traps focus.</p>
+      <button id="close">Close</button>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/modal-dialog/script.js
+++ b/modal-dialog/script.js
@@ -1,0 +1,37 @@
+const openBtn = document.getElementById('open');
+const modal = document.getElementById('modal');
+const closeBtn = document.getElementById('close');
+
+function openModal() {
+  modal.classList.remove('hidden');
+  modal.setAttribute('aria-hidden', 'false');
+  const focusable = modal.querySelectorAll('button');
+  modal.firstFocusable = focusable[0];
+  modal.lastFocusable = focusable[focusable.length - 1];
+  modal.firstFocusable.focus();
+}
+
+function closeModal() {
+  modal.classList.add('hidden');
+  modal.setAttribute('aria-hidden', 'true');
+  openBtn.focus();
+}
+
+openBtn.addEventListener('click', openModal);
+closeBtn.addEventListener('click', closeModal);
+
+document.addEventListener('keydown', e => {
+  if (modal.classList.contains('hidden')) return;
+  if (e.key === 'Escape') {
+    closeModal();
+  } else if (e.key === 'Tab') {
+    const active = document.activeElement;
+    if (e.shiftKey && active === modal.firstFocusable) {
+      e.preventDefault();
+      modal.lastFocusable.focus();
+    } else if (!e.shiftKey && active === modal.lastFocusable) {
+      e.preventDefault();
+      modal.firstFocusable.focus();
+    }
+  }
+});

--- a/modal-dialog/styles.css
+++ b/modal-dialog/styles.css
@@ -1,0 +1,27 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal .content {
+  background: white;
+  padding: 20px;
+  max-width: 300px;
+}

--- a/progress-loading/index.html
+++ b/progress-loading/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Progress and Loading</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Progress and Loading</h1>
+  <button id="start">Start Loading</button>
+  <div id="spinner" class="spinner"></div>
+  <div id="progress" class="progress"><div class="bar"></div></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/progress-loading/script.js
+++ b/progress-loading/script.js
@@ -1,0 +1,19 @@
+const btn = document.getElementById('start');
+const spinner = document.getElementById('spinner');
+const progress = document.getElementById('progress');
+const bar = progress.querySelector('.bar');
+
+btn.addEventListener('click', () => {
+  let width = 0;
+  spinner.style.display = 'block';
+  progress.style.display = 'block';
+  bar.style.width = '0';
+  const interval = setInterval(() => {
+    width += 10;
+    bar.style.width = width + '%';
+    if (width >= 100) {
+      clearInterval(interval);
+      spinner.style.display = 'none';
+    }
+  }, 500);
+});

--- a/progress-loading/styles.css
+++ b/progress-loading/styles.css
@@ -1,0 +1,35 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  display: none;
+  margin-top: 20px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.progress {
+  width: 100%;
+  max-width: 400px;
+  height: 20px;
+  border: 1px solid #333;
+  margin-top: 20px;
+  display: none;
+}
+
+.bar {
+  height: 100%;
+  width: 0;
+  background: #4caf50;
+}

--- a/storage-preferences/index.html
+++ b/storage-preferences/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Storage Preferences</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Storage Preferences</h1>
+  <button id="theme-toggle">Toggle Theme</button>
+  <p>Session visits: <span id="count"></span></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/storage-preferences/script.js
+++ b/storage-preferences/script.js
@@ -1,0 +1,15 @@
+const btn = document.getElementById('theme-toggle');
+const countEl = document.getElementById('count');
+
+const savedTheme = localStorage.getItem('theme') || 'light';
+document.body.dataset.theme = savedTheme;
+
+let visits = Number(sessionStorage.getItem('visits') || 0) + 1;
+sessionStorage.setItem('visits', visits);
+countEl.textContent = visits;
+
+btn.addEventListener('click', () => {
+  const next = document.body.dataset.theme === 'light' ? 'dark' : 'light';
+  document.body.dataset.theme = next;
+  localStorage.setItem('theme', next);
+});

--- a/storage-preferences/styles.css
+++ b/storage-preferences/styles.css
@@ -1,0 +1,12 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+  background: #fff;
+  color: #000;
+}
+
+body[data-theme="dark"] {
+  background: #222;
+  color: #fff;
+}

--- a/video-player/index.html
+++ b/video-player/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Custom Video Player</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Custom Video Player</h1>
+  <video id="video" width="400">
+    <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4" />
+    <track src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.vtt" kind="captions" srclang="en" label="English" />
+  </video>
+  <div class="controls">
+    <button id="play">Play</button>
+    <label>Speed
+      <select id="speed">
+        <option value="0.5">0.5x</option>
+        <option value="1" selected>1x</option>
+        <option value="1.5">1.5x</option>
+        <option value="2">2x</option>
+      </select>
+    </label>
+    <label><input type="checkbox" id="captions" checked /> Captions</label>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/video-player/script.js
+++ b/video-player/script.js
@@ -1,0 +1,23 @@
+const video = document.getElementById('video');
+const play = document.getElementById('play');
+const speed = document.getElementById('speed');
+const captions = document.getElementById('captions');
+
+play.addEventListener('click', () => {
+  if (video.paused) {
+    video.play();
+    play.textContent = 'Pause';
+  } else {
+    video.pause();
+    play.textContent = 'Play';
+  }
+});
+
+speed.addEventListener('change', () => {
+  video.playbackRate = parseFloat(speed.value);
+});
+
+captions.addEventListener('change', () => {
+  const track = video.textTracks[0];
+  track.mode = captions.checked ? 'showing' : 'hidden';
+});

--- a/video-player/styles.css
+++ b/video-player/styles.css
@@ -1,0 +1,16 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+video {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.controls {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}

--- a/web-animations/index.html
+++ b/web-animations/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Web Animations API</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Web Animations API</h1>
+  <div id="box"></div>
+  <button id="animate">Animate</button>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/web-animations/script.js
+++ b/web-animations/script.js
@@ -1,0 +1,12 @@
+const box = document.getElementById('box');
+
+document.getElementById('animate').addEventListener('click', () => {
+  box.animate([
+    { transform: 'translateX(0)' },
+    { transform: 'translateX(200px)' },
+    { transform: 'translateX(0)' }
+  ], {
+    duration: 1000,
+    iterations: 1
+  });
+});

--- a/web-animations/styles.css
+++ b/web-animations/styles.css
@@ -1,0 +1,12 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+#box {
+  width: 50px;
+  height: 50px;
+  background: salmon;
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
## Summary
- add examples for grid masonry layout, keyboard shortcuts, storage preferences, progress/loading indicators, canvas drawing, Web Animations API, form autosave, custom video player, clip-path shapes, canvas chart, and accessible modal
- update README to list new showcases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960383d55c833382c708c0bb0e8587