### PR TITLE
Add interactive index page with previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository is a playground for showcasing web capabilities using **HTML**, **CSS**, and **JavaScript**. The goal is to collect small, self-contained examples that demonstrate native browser features without relying on external frameworks.
 
+Open index.html for an interactive menu that previews each showcase.
+
 ## Showcases
 
 - [Responsive layout with header, footer, and side navigation](responsive-layout/)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Web Native Showcase</title>
+  <style>
+    body {
+      margin: 0;
+      display: flex;
+      height: 100vh;
+      font-family: Arial, sans-serif;
+    }
+    nav {
+      width: 260px;
+      overflow-y: auto;
+      border-right: 1px solid #ddd;
+      padding: 1rem;
+    }
+    nav ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    nav li {
+      margin-bottom: 0.5rem;
+    }
+    nav a {
+      text-decoration: none;
+      color: #333;
+    }
+    nav a:hover {
+      text-decoration: underline;
+    }
+    #preview {
+      flex: 1;
+    }
+    #preview iframe {
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <ul id="menu"></ul>
+  </nav>
+  <div id="preview">
+    <iframe id="preview-frame" title="Preview"></iframe>
+  </div>
+  <script>
+    async function buildMenu() {
+      try {
+        const res = await fetch('README.md');
+        const text = await res.text();
+        const lines = text.split('\n');
+        const list = document.getElementById('menu');
+        const pattern = /^- \[(.+?)\]\(([^)]+)\)/;
+        lines.forEach(line => {
+          const match = line.match(pattern);
+          if (match) {
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.textContent = match[1];
+            a.href = '#';
+            a.dataset.link = match[2];
+            a.addEventListener('click', e => {
+              e.preventDefault();
+              document.getElementById('preview-frame').src = a.dataset.link + 'index.html';
+            });
+            li.appendChild(a);
+            list.appendChild(li);
+          }
+        });
+      } catch (e) {
+        console.error('Failed to load menu', e);
+      }
+    }
+    buildMenu();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add root index.html listing showcases and loading selected demo in an iframe
- note the new interactive index page in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960d2a36a48333999f5ea341e1b50b