### PR TITLE
Add forms and user interaction demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,13 @@ Open index.html for an interactive menu that previews each showcase.
 - [Canvas drawing app with touch and mouse support](canvas-drawing/)
 - [Web Animations API scripted animations](web-animations/)
 - [Form autosave and restore from localStorage](form-autosave/)
+- [Forms & User Interaction demos](forms-user-interaction/)
 - [Custom video player with speed and captions](video-player/)
 - [CSS clip-path creative shapes and hover effects](clip-path/)
 - [Interactive Canvas chart](canvas-svg-charts/)
 - [Accessible modal dialog with focus trapping](modal-dialog/)
 
 ## Planned Showcases
-
-### Forms & User Interaction
-1. Multi-step form wizard with progress tracking  
-2. Autocomplete search input using datalist  
-3. Inline editable table cells  
-4. Date & time pickers with native `<input>` types  
-5. Range slider with dynamic value display  
-6. Tag input with keyboard navigation  
-7. File drag-and-drop zone with validation  
-8. Print-friendly invoice generator using `@media print`  
-9. Auto-growing textarea  
-10. Password strength meter  
-11. Form with conditional fields (show/hide based on selection)  
-12. Email verification format checker  
-13. Signature pad using `<canvas>`  
-14. Inline markdown editor with preview  
-15. Character counter for text inputs  
 
 ### CSS Layout & Styling
 16. Pure CSS responsive card grid  

--- a/forms-user-interaction/index.html
+++ b/forms-user-interaction/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Forms & User Interaction Demos</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Forms & User Interaction Demos</h1>
+
+  <!-- 1. Multi-step form wizard with progress tracking -->
+  <section id="wizard">
+    <h2>Multi-step Form Wizard</h2>
+    <form id="wizard-form">
+      <div class="step active">
+        <label>Name <input type="text" required></label>
+      </div>
+      <div class="step">
+        <label>Email <input type="email" required></label>
+      </div>
+      <div class="step">
+        <p>All done!</p>
+      </div>
+      <div class="buttons">
+        <button type="button" id="prevBtn">Previous</button>
+        <button type="button" id="nextBtn">Next</button>
+      </div>
+      <progress id="progress" value="1" max="3"></progress>
+    </form>
+  </section>
+
+  <!-- 2. Autocomplete search input using datalist -->
+  <section>
+    <h2>Autocomplete Search</h2>
+    <input list="fruit-list" id="autocomplete" placeholder="Pick a fruit" />
+    <datalist id="fruit-list">
+      <option value="Apple"></option>
+      <option value="Banana"></option>
+      <option value="Cherry"></option>
+      <option value="Grape"></option>
+      <option value="Orange"></option>
+    </datalist>
+  </section>
+
+  <!-- 3. Inline editable table cells -->
+  <section>
+    <h2>Inline Editable Table</h2>
+    <table id="editable-table">
+      <tr><th>Name</th><th>Age</th></tr>
+      <tr><td contenteditable>Alice</td><td contenteditable>30</td></tr>
+      <tr><td contenteditable>Bob</td><td contenteditable>25</td></tr>
+    </table>
+  </section>
+
+  <!-- 4. Date & time pickers with native input types -->
+  <section>
+    <h2>Date & Time Pickers</h2>
+    <input type="date" id="date-picker" />
+    <input type="time" id="time-picker" />
+  </section>
+
+  <!-- 5. Range slider with dynamic value display -->
+  <section>
+    <h2>Range Slider</h2>
+    <input type="range" id="range" min="0" max="100" value="50" />
+    <span id="range-value">50</span>
+  </section>
+
+  <!-- 6. Tag input with keyboard navigation -->
+  <section>
+    <h2>Tag Input</h2>
+    <div id="tag-input" class="tag-input">
+      <input type="text" id="tag-field" placeholder="Add a tag and press Enter" />
+    </div>
+  </section>
+
+  <!-- 7. File drag-and-drop zone with validation -->
+  <section>
+    <h2>File Drag & Drop</h2>
+    <div id="drop-zone">Drop an image here</div>
+    <p id="drop-result"></p>
+  </section>
+
+  <!-- 8. Print-friendly invoice generator using @media print -->
+  <section id="invoice">
+    <h2>Invoice</h2>
+    <button id="print-button">Print Invoice</button>
+    <div class="invoice">
+      <table>
+        <tr><th>Item</th><th>Price</th></tr>
+        <tr><td>Widget</td><td>$10.00</td></tr>
+        <tr><td>Gadget</td><td>$15.00</td></tr>
+        <tr><td>Total</td><td>$25.00</td></tr>
+      </table>
+    </div>
+  </section>
+
+  <!-- 9. Auto-growing textarea -->
+  <section>
+    <h2>Auto-growing Textarea</h2>
+    <textarea id="autogrow" rows="1" placeholder="Type here..."></textarea>
+  </section>
+
+  <!-- 10. Password strength meter -->
+  <section>
+    <h2>Password Strength Meter</h2>
+    <input type="password" id="password" />
+    <meter id="strength" min="0" max="4" value="0"></meter>
+  </section>
+
+  <!-- 11. Form with conditional fields -->
+  <section>
+    <h2>Conditional Fields</h2>
+    <label>Contact Method
+      <select id="contact-method">
+        <option value="email">Email</option>
+        <option value="phone">Phone</option>
+        <option value="other">Other</option>
+      </select>
+    </label>
+    <input type="text" id="other-contact" placeholder="Please specify" hidden />
+  </section>
+
+  <!-- 12. Email verification format checker -->
+  <section>
+    <h2>Email Format Checker</h2>
+    <input type="email" id="email-check" placeholder="Enter your email" />
+    <span id="email-msg"></span>
+  </section>
+
+  <!-- 13. Signature pad using canvas -->
+  <section>
+    <h2>Signature Pad</h2>
+    <canvas id="signature" width="300" height="150"></canvas>
+    <button id="clear-signature">Clear</button>
+  </section>
+
+  <!-- 14. Inline markdown editor with preview -->
+  <section>
+    <h2>Markdown Editor</h2>
+    <textarea id="md-input" placeholder="# Heading\n\nSome **bold** text."></textarea>
+    <div id="md-preview"></div>
+  </section>
+
+  <!-- 15. Character counter for text inputs -->
+  <section>
+    <h2>Character Counter</h2>
+    <input type="text" id="char-input" maxlength="100" />
+    <span id="char-count">0/100</span>
+  </section>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/forms-user-interaction/script.js
+++ b/forms-user-interaction/script.js
@@ -1,0 +1,198 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // 1. Multi-step form wizard
+  const steps = document.querySelectorAll('#wizard-form .step');
+  const prevBtn = document.getElementById('prevBtn');
+  const nextBtn = document.getElementById('nextBtn');
+  const progress = document.getElementById('progress');
+  let current = 0;
+  function showStep(i) {
+    steps.forEach((s, idx) => s.classList.toggle('active', idx === i));
+    prevBtn.disabled = i === 0;
+    nextBtn.textContent = i === steps.length - 1 ? 'Submit' : 'Next';
+    progress.value = i + 1;
+  }
+  prevBtn.addEventListener('click', () => {
+    if (current > 0) {
+      current--;
+      showStep(current);
+    }
+  });
+  nextBtn.addEventListener('click', () => {
+    if (current < steps.length - 1) {
+      current++;
+      showStep(current);
+    } else {
+      alert('Form submitted!');
+    }
+  });
+  showStep(0);
+
+  // 5. Range slider display
+  const range = document.getElementById('range');
+  const rangeValue = document.getElementById('range-value');
+  range.addEventListener('input', () => {
+    rangeValue.textContent = range.value;
+  });
+
+  // 6. Tag input
+  const tagInput = document.getElementById('tag-input');
+  const tagField = document.getElementById('tag-field');
+  function addTag(text) {
+    const span = document.createElement('span');
+    span.className = 'tag';
+    span.textContent = text;
+    tagInput.insertBefore(span, tagField);
+  }
+  tagField.addEventListener('keydown', e => {
+    const selected = tagInput.querySelector('.tag.selected');
+    if (e.key === 'Enter' && tagField.value.trim()) {
+      addTag(tagField.value.trim());
+      tagField.value = '';
+      e.preventDefault();
+    } else if (e.key === 'Backspace' && !tagField.value) {
+      if (selected) {
+        selected.remove();
+      } else {
+        const lastTag = tagInput.children[tagInput.children.length - 2];
+        if (lastTag) lastTag.classList.add('selected');
+      }
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft' && tagField.selectionStart === 0) {
+      const lastTag = tagInput.children[tagInput.children.length - 2];
+      if (lastTag) lastTag.classList.add('selected');
+    } else if (e.key === 'ArrowRight' && selected) {
+      selected.classList.remove('selected');
+    }
+  });
+  tagInput.addEventListener('click', e => {
+    if (e.target.classList.contains('tag')) {
+      e.target.classList.toggle('selected');
+    } else {
+      const selected = tagInput.querySelector('.tag.selected');
+      if (selected) selected.classList.remove('selected');
+      tagField.focus();
+    }
+  });
+
+  // 7. File drag-and-drop
+  const dropZone = document.getElementById('drop-zone');
+  const dropResult = document.getElementById('drop-result');
+  ['dragenter', 'dragover'].forEach(evt => {
+    dropZone.addEventListener(evt, e => {
+      e.preventDefault();
+      dropZone.classList.add('hover');
+    });
+  });
+  ['dragleave', 'drop'].forEach(evt => {
+    dropZone.addEventListener(evt, e => {
+      e.preventDefault();
+      dropZone.classList.remove('hover');
+    });
+  });
+  dropZone.addEventListener('drop', e => {
+    const file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith('image/')) {
+      dropResult.textContent = `Loaded ${file.name}`;
+    } else {
+      dropResult.textContent = 'Only image files are allowed.';
+    }
+  });
+
+  // 8. Print invoice
+  document.getElementById('print-button').addEventListener('click', () => window.print());
+
+  // 9. Auto-growing textarea
+  const auto = document.getElementById('autogrow');
+  const resize = () => {
+    auto.style.height = 'auto';
+    auto.style.height = auto.scrollHeight + 'px';
+  };
+  auto.addEventListener('input', resize);
+  resize();
+
+  // 10. Password strength meter
+  const password = document.getElementById('password');
+  const strength = document.getElementById('strength');
+  password.addEventListener('input', () => {
+    const val = password.value;
+    let score = 0;
+    if (val.length >= 8) score++;
+    if (/[A-Z]/.test(val)) score++;
+    if (/[a-z]/.test(val)) score++;
+    if (/\d/.test(val)) score++;
+    strength.value = score;
+  });
+
+  // 11. Conditional fields
+  const contact = document.getElementById('contact-method');
+  const other = document.getElementById('other-contact');
+  contact.addEventListener('change', () => {
+    other.hidden = contact.value !== 'other';
+  });
+
+  // 12. Email verification format checker
+  const emailCheck = document.getElementById('email-check');
+  const emailMsg = document.getElementById('email-msg');
+  emailCheck.addEventListener('input', () => {
+    if (!emailCheck.value) {
+      emailMsg.textContent = '';
+      return;
+    }
+    if (emailCheck.validity.valid) {
+      emailMsg.textContent = '✓';
+      emailMsg.style.color = 'green';
+    } else {
+      emailMsg.textContent = 'Invalid email';
+      emailMsg.style.color = 'red';
+    }
+  });
+
+  // 13. Signature pad
+  const canvas = document.getElementById('signature');
+  const ctx = canvas.getContext('2d');
+  let drawing = false;
+  const getPos = e => ({
+    x: e.offsetX ?? e.touches[0].clientX - canvas.getBoundingClientRect().left,
+    y: e.offsetY ?? e.touches[0].clientY - canvas.getBoundingClientRect().top
+  });
+  canvas.addEventListener('pointerdown', e => {
+    drawing = true;
+    const pos = getPos(e);
+    ctx.beginPath();
+    ctx.moveTo(pos.x, pos.y);
+  });
+  canvas.addEventListener('pointermove', e => {
+    if (!drawing) return;
+    const pos = getPos(e);
+    ctx.lineTo(pos.x, pos.y);
+    ctx.stroke();
+  });
+  canvas.addEventListener('pointerup', () => drawing = false);
+  canvas.addEventListener('pointerleave', () => drawing = false);
+  document.getElementById('clear-signature').addEventListener('click', () => ctx.clearRect(0, 0, canvas.width, canvas.height));
+
+  // 14. Markdown editor with preview
+  const mdInput = document.getElementById('md-input');
+  const mdPreview = document.getElementById('md-preview');
+  const renderMarkdown = text => {
+    return text
+      .replace(/^### (.*$)/gim, '<h3>$1</h3>')
+      .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+      .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+      .replace(/\*\*(.*?)\*\*/gim, '<strong>$1</strong>')
+      .replace(/\*(.*?)\*/gim, '<em>$1</em>')
+      .replace(/\n/g, '<br>');
+  };
+  const updatePreview = () => {
+    mdPreview.innerHTML = renderMarkdown(mdInput.value);
+  };
+  mdInput.addEventListener('input', updatePreview);
+  updatePreview();
+
+  // 15. Character counter
+  const charInput = document.getElementById('char-input');
+  const charCount = document.getElementById('char-count');
+  charInput.addEventListener('input', () => {
+    charCount.textContent = `${charInput.value.length}/100`;
+  });
+});

--- a/forms-user-interaction/styles.css
+++ b/forms-user-interaction/styles.css
@@ -1,0 +1,56 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+}
+section {
+  margin-bottom: 2rem;
+}
+
+/* Multi-step wizard */
+.step { display: none; }
+.step.active { display: block; }
+.buttons { margin-top: 1rem; }
+.buttons button { margin-right: 0.5rem; }
+
+/* Tag input */
+.tag-input {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  border: 1px solid #ccc;
+  padding: 0.25rem;
+}
+.tag {
+  background: #e0e0e0;
+  padding: 0.25rem 0.5rem;
+  margin: 0.25rem;
+  border-radius: 3px;
+}
+.tag.selected { outline: 1px solid #333; }
+.tag-input input { border: none; flex: 1; min-width: 120px; }
+.tag-input input:focus { outline: none; }
+
+/* Drop zone */
+#drop-zone {
+  border: 2px dashed #999;
+  padding: 1rem;
+  text-align: center;
+}
+#drop-zone.hover { background: #f0f0f0; }
+
+/* Invoice */
+.invoice table { width: 300px; border-collapse: collapse; }
+.invoice th, .invoice td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+@media print {
+  #print-button { display: none; }
+}
+
+/* Signature pad */
+#signature { border: 1px solid #ccc; cursor: crosshair; }
+
+/* Markdown editor */
+#md-input { width: 100%; height: 100px; }
+#md-preview { border: 1px solid #ccc; padding: 0.5rem; min-height: 100px; }
+
+/* Character counter */
+#char-count { margin-left: 0.5rem; }


### PR DESCRIPTION
## Summary
- add comprehensive Forms & User Interaction demo page showcasing 15 native HTML/CSS/JS features
- wire up JavaScript for tag input, multi-step wizard, drag-and-drop validation, markdown preview, signature pad, and more
- document new demos in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960f5ab3588333ad15405dbcfa2188