### PR TITLE
Add CSS layout and styling showcase examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,28 +32,26 @@ Open index.html for an interactive menu that previews each showcase.
 - [CSS clip-path creative shapes and hover effects](clip-path/)
 - [Interactive Canvas chart](canvas-svg-charts/)
 - [Accessible modal dialog with focus trapping](modal-dialog/)
+- [Pure CSS responsive card grid](responsive-card-grid/)
+- [CSS only tooltip variations](css-tooltips/)
+- [Animated burger menu with pure CSS](css-burger-menu/)
+- [Responsive image comparison slider (before/after)](image-comparison-slider/)
+- [Sticky table headers & columns](sticky-table/)
+- [CSS variable theming switcher](css-theme-switcher/)
+- [Pure CSS loading animations](css-loading-animations/)
+- [CSS shape divider for sections](css-shape-divider/)
+- [CSS parallax scrolling effect](css-parallax/)
+- [CSS only dropdown navigation](css-dropdown-navigation/)
+- [CSS only image zoom on hover](css-image-zoom/)
+- [CSS text gradient animations](css-text-gradient/)
+- [Responsive split-screen layout](split-screen-layout/)
+- [CSS floating labels for forms](floating-labels/)
+- [Glassmorphism UI effect](glassmorphism/)
 
 ## Planned Showcases
 
-### CSS Layout & Styling
-16. Pure CSS responsive card grid  
-17. CSS only tooltip variations  
-18. Animated burger menu with pure CSS  
-19. Responsive image comparison slider (before/after)  
-20. Sticky table headers & columns  
-21. CSS variable theming switcher  
-22. Pure CSS loading animations  
-23. CSS shape divider for sections  
-24. CSS parallax scrolling effect  
-25. CSS only dropdown navigation  
-26. CSS only image zoom on hover  
-27. CSS text gradient animations  
-28. Responsive split-screen layout  
-29. CSS floating labels for forms  
-30. Glassmorphism UI effect  
-
 ### Media & Graphics
-31. Webcam photo capture using getUserMedia API  
+31. Webcam photo capture using getUserMedia API
 32. Video recording and playback in browser  
 33. Audio recording with live waveform visualizer  
 34. Image filters with CSS & Canvas  

--- a/css-burger-menu/index.html
+++ b/css-burger-menu/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pure CSS Burger Menu</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <input type="checkbox" id="toggle" />
+  <label for="toggle" class="burger"><span></span></label>
+  <nav class="menu">
+    <a href="#">Home</a>
+    <a href="#">About</a>
+    <a href="#">Contact</a>
+  </nav>
+</body>
+</html>

--- a/css-burger-menu/styles.css
+++ b/css-burger-menu/styles.css
@@ -1,0 +1,60 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+}
+#toggle {
+  display: none;
+}
+.burger {
+  width: 30px;
+  height: 22px;
+  position: relative;
+  margin: 1rem;
+  cursor: pointer;
+  display: inline-block;
+}
+.burger span,
+.burger span::before,
+.burger span::after {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: #333;
+  transition: 0.3s;
+}
+.burger span::before {
+  content: "";
+  top: -8px;
+}
+.burger span::after {
+  content: "";
+  top: 8px;
+}
+#toggle:checked + .burger span {
+  background: transparent;
+}
+#toggle:checked + .burger span::before {
+  transform: translateY(8px) rotate(45deg);
+}
+#toggle:checked + .burger span::after {
+  transform: translateY(-8px) rotate(-45deg);
+}
+.menu {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #eee;
+  padding: 4rem 1rem 1rem;
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+}
+#toggle:checked ~ .menu {
+  display: flex;
+}
+.menu a {
+  text-decoration: none;
+  color: #333;
+}

--- a/css-dropdown-navigation/index.html
+++ b/css-dropdown-navigation/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Dropdown Navigation</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="#">Home</a></li>
+      <li class="dropdown">
+        <a href="#">Services</a>
+        <ul class="submenu">
+          <li><a href="#">Design</a></li>
+          <li><a href="#">Development</a></li>
+          <li><a href="#">SEO</a></li>
+        </ul>
+      </li>
+      <li><a href="#">Contact</a></li>
+    </ul>
+  </nav>
+</body>
+</html>

--- a/css-dropdown-navigation/styles.css
+++ b/css-dropdown-navigation/styles.css
@@ -1,0 +1,31 @@
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  background: #333;
+}
+nav a {
+  color: #fff;
+  padding: 1rem;
+  display: block;
+  text-decoration: none;
+}
+nav li {
+  position: relative;
+}
+nav ul.submenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #444;
+  min-width: 150px;
+  flex-direction: column;
+}
+nav li:hover > ul.submenu {
+  display: flex;
+}
+nav ul.submenu a {
+  padding: 0.5rem 1rem;
+}

--- a/css-image-zoom/index.html
+++ b/css-image-zoom/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Image Zoom</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Image Zoom on Hover</h1>
+  <div class="zoom">
+    <img src="https://picsum.photos/400/300" alt="Sample" />
+  </div>
+</body>
+</html>

--- a/css-image-zoom/styles.css
+++ b/css-image-zoom/styles.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 2rem;
+}
+.zoom {
+  overflow: hidden;
+  width: 400px;
+}
+.zoom img {
+  display: block;
+  width: 100%;
+  transition: transform 0.3s;
+}
+.zoom:hover img {
+  transform: scale(1.2);
+}

--- a/css-loading-animations/index.html
+++ b/css-loading-animations/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Loading Animations</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>CSS Loading Animations</h1>
+  <div class="spinner"></div>
+  <div class="dots">
+    <span></span><span></span><span></span>
+  </div>
+  <div class="bar"></div>
+</body>
+</html>

--- a/css-loading-animations/styles.css
+++ b/css-loading-animations/styles.css
@@ -1,0 +1,63 @@
+body {
+  font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+  padding: 2rem;
+}
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.dots span {
+  width: 8px;
+  height: 8px;
+  background: #333;
+  border-radius: 50%;
+  display: inline-block;
+  margin: 0 2px;
+  animation: bounce 0.6s infinite alternate;
+}
+.dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+@keyframes bounce {
+  to {
+    transform: translateY(-8px);
+  }
+}
+.bar {
+  width: 80px;
+  height: 8px;
+  background: #ccc;
+  position: relative;
+  overflow: hidden;
+}
+.bar::before {
+  content: "";
+  position: absolute;
+  left: -40px;
+  top: 0;
+  width: 40px;
+  height: 100%;
+  background: #333;
+  animation: slide 1s linear infinite;
+}
+@keyframes slide {
+  to {
+    left: 80px;
+  }
+}

--- a/css-parallax/index.html
+++ b/css-parallax/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Parallax</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <section class="parallax"></section>
+  <section class="content">
+    <h1>Parallax Scrolling</h1>
+    <p>Scroll to see the background move slower than foreground content.</p>
+  </section>
+  <section class="parallax second"></section>
+</body>
+</html>

--- a/css-parallax/styles.css
+++ b/css-parallax/styles.css
@@ -1,0 +1,18 @@
+body,
+html {
+  margin: 0;
+}
+.parallax {
+  background-image: url('https://picsum.photos/seed/p1/1200/800');
+  min-height: 60vh;
+  background-attachment: fixed;
+  background-size: cover;
+  background-position: center;
+}
+.parallax.second {
+  background-image: url('https://picsum.photos/seed/p2/1200/800');
+}
+.content {
+  padding: 3rem;
+  font-family: Arial, sans-serif;
+}

--- a/css-shape-divider/index.html
+++ b/css-shape-divider/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Shape Divider</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <section class="top">
+    <h1>Section One</h1>
+  </section>
+  <div class="divider"></div>
+  <section class="bottom">
+    <h1>Section Two</h1>
+  </section>
+</body>
+</html>

--- a/css-shape-divider/styles.css
+++ b/css-shape-divider/styles.css
@@ -1,0 +1,30 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  text-align: center;
+}
+section {
+  padding: 4rem 1rem;
+  color: #fff;
+}
+.top {
+  background: #3498db;
+}
+.bottom {
+  background: #2ecc71;
+}
+.divider {
+  position: relative;
+  height: 80px;
+  background: #3498db;
+}
+.divider::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 100%;
+  background: #2ecc71;
+  clip-path: polygon(0 100%, 100% 0, 100% 100%);
+}

--- a/css-text-gradient/index.html
+++ b/css-text-gradient/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Text Gradient Animation</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1 class="gradient">Animated Gradient Text</h1>
+</body>
+</html>

--- a/css-text-gradient/styles.css
+++ b/css-text-gradient/styles.css
@@ -1,0 +1,20 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+.gradient {
+  font-size: 3rem;
+  background: linear-gradient(90deg, #ff0080, #00b3ff, #ff0080);
+  background-size: 200%;
+  -webkit-background-clip: text;
+  color: transparent;
+  animation: move 3s linear infinite;
+}
+@keyframes move {
+  to {
+    background-position: -200% 0;
+  }
+}

--- a/css-theme-switcher/index.html
+++ b/css-theme-switcher/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Variable Theme Switcher</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="controls">
+    <button data-theme="light">Light</button>
+    <button data-theme="dark">Dark</button>
+  </div>
+  <h1>Themed Page</h1>
+  <p>Switch themes to see CSS variables in action.</p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/css-theme-switcher/script.js
+++ b/css-theme-switcher/script.js
@@ -1,0 +1,5 @@
+document.querySelectorAll('[data-theme]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.body.classList.toggle('dark', btn.dataset.theme === 'dark');
+  });
+});

--- a/css-theme-switcher/styles.css
+++ b/css-theme-switcher/styles.css
@@ -1,0 +1,21 @@
+:root {
+  --bg: #fff;
+  --fg: #000;
+}
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+  transition: background 0.3s, color 0.3s;
+}
+body.dark {
+  --bg: #222;
+  --fg: #eee;
+}
+.controls {
+  margin-bottom: 1rem;
+}
+button {
+  margin-right: 0.5rem;
+}

--- a/css-tooltips/index.html
+++ b/css-tooltips/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Tooltips</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>CSS Only Tooltips</h1>
+  <div class="tooltip top" data-tooltip="Top tooltip">Hover me (top)</div>
+  <div class="tooltip right" data-tooltip="Right tooltip">Hover me (right)</div>
+  <div class="tooltip bottom" data-tooltip="Bottom tooltip">Hover me (bottom)</div>
+  <div class="tooltip left" data-tooltip="Left tooltip">Hover me (left)</div>
+</body>
+</html>

--- a/css-tooltips/styles.css
+++ b/css-tooltips/styles.css
@@ -1,0 +1,47 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+.tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  background: #333;
+  color: #fff;
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s, transform 0.2s;
+}
+.tooltip:hover::after {
+  opacity: 1;
+}
+.tooltip.top::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -0.5rem);
+}
+.tooltip.right::after {
+  left: 100%;
+  top: 50%;
+  transform: translate(0.5rem, -50%);
+}
+.tooltip.bottom::after {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 0.5rem);
+}
+.tooltip.left::after {
+  right: 100%;
+  top: 50%;
+  transform: translate(-0.5rem, -50%);
+}

--- a/floating-labels/index.html
+++ b/floating-labels/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Floating Labels</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <form>
+    <div class="field">
+      <input type="text" id="name" placeholder=" " />
+      <label for="name">Name</label>
+    </div>
+    <div class="field">
+      <input type="email" id="email" placeholder=" " />
+      <label for="email">Email</label>
+    </div>
+  </form>
+</body>
+</html>

--- a/floating-labels/styles.css
+++ b/floating-labels/styles.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 2rem;
+}
+.field {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+input {
+  padding: 1rem 0.5rem 0.5rem;
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+label {
+  position: absolute;
+  left: 0.5rem;
+  top: 1rem;
+  transition: 0.2s;
+  background: #fff;
+  padding: 0 0.25rem;
+  color: #666;
+}
+input:focus + label,
+input:not(:placeholder-shown) + label {
+  top: -0.5rem;
+  font-size: 0.75rem;
+  color: #333;
+}

--- a/glassmorphism/index.html
+++ b/glassmorphism/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glassmorphism</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="glass">
+    <h1>Glassmorphism</h1>
+    <p>Frosted glass UI effect using backdrop-filter.</p>
+  </div>
+</body>
+</html>

--- a/glassmorphism/styles.css
+++ b/glassmorphism/styles.css
@@ -1,0 +1,19 @@
+body {
+  margin: 0;
+  height: 100vh;
+  background: url('https://picsum.photos/seed/bg/1200/800') center/cover no-repeat;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: Arial, sans-serif;
+}
+.glass {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 2rem;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  text-align: center;
+  color: #fff;
+}

--- a/image-comparison-slider/index.html
+++ b/image-comparison-slider/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Comparison Slider</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Image Comparison Slider</h1>
+  <div class="comparison">
+    <img src="https://picsum.photos/800/400?image=10" alt="Before" />
+    <div class="overlay">
+      <img src="https://picsum.photos/800/400?image=20" alt="After" />
+    </div>
+    <input type="range" min="0" max="100" value="50" id="slider" aria-label="Comparison slider" />
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/image-comparison-slider/script.js
+++ b/image-comparison-slider/script.js
@@ -1,0 +1,5 @@
+const slider = document.getElementById('slider');
+const overlay = document.querySelector('.overlay');
+slider.addEventListener('input', e => {
+  overlay.style.width = e.target.value + '%';
+});

--- a/image-comparison-slider/styles.css
+++ b/image-comparison-slider/styles.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+}
+.comparison {
+  position: relative;
+  max-width: 800px;
+  margin: auto;
+}
+.comparison img {
+  display: block;
+  width: 100%;
+}
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  overflow: hidden;
+}
+.overlay img {
+  width: 100%;
+}
+#slider {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80%;
+}

--- a/responsive-card-grid/index.html
+++ b/responsive-card-grid/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Responsive Card Grid</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Responsive Card Grid</h1>
+  <div class="grid">
+    <div class="card">Card 1</div>
+    <div class="card">Card 2</div>
+    <div class="card">Card 3</div>
+    <div class="card">Card 4</div>
+    <div class="card">Card 5</div>
+    <div class="card">Card 6</div>
+  </div>
+</body>
+</html>

--- a/responsive-card-grid/styles.css
+++ b/responsive-card-grid/styles.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+.card {
+  background: #f0f0f0;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 8px;
+}

--- a/split-screen-layout/index.html
+++ b/split-screen-layout/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Split Screen Layout</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="split left">
+    <h1>Left Side</h1>
+  </div>
+  <div class="split right">
+    <h1>Right Side</h1>
+  </div>
+</body>
+</html>

--- a/split-screen-layout/styles.css
+++ b/split-screen-layout/styles.css
@@ -1,0 +1,30 @@
+body,
+html {
+  margin: 0;
+  height: 100%;
+}
+body {
+  display: flex;
+}
+.split {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-family: Arial, sans-serif;
+}
+.left {
+  background: #e74c3c;
+}
+.right {
+  background: #8e44ad;
+}
+@media (max-width: 600px) {
+  body {
+    flex-direction: column;
+  }
+  .split {
+    height: 50%;
+  }
+}

--- a/sticky-table/index.html
+++ b/sticky-table/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky Table Headers & Columns</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Sticky Table Headers & Columns</h1>
+  <div class="table-container">
+    <table>
+      <thead>
+        <tr><th>Item</th><th>Q1</th><th>Q2</th><th>Q3</th><th>Q4</th></tr>
+      </thead>
+      <tbody>
+        <tr><th>Apples</th><td>10</td><td>20</td><td>30</td><td>40</td></tr>
+        <tr><th>Bananas</th><td>12</td><td>22</td><td>32</td><td>42</td></tr>
+        <tr><th>Cherries</th><td>14</td><td>24</td><td>34</td><td>44</td></tr>
+        <tr><th>Dates</th><td>16</td><td>26</td><td>36</td><td>46</td></tr>
+        <tr><th>Elderberry</th><td>18</td><td>28</td><td>38</td><td>48</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/sticky-table/styles.css
+++ b/sticky-table/styles.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 1rem;
+}
+.table-container {
+  max-width: 600px;
+  overflow: auto;
+}
+table {
+  border-collapse: collapse;
+  min-width: 600px;
+}
+th,
+td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+thead th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+}
+tbody th {
+  position: sticky;
+  left: 0;
+  background: #f9f9f9;
+}


### PR DESCRIPTION
## Summary
- expand showcase with responsive card grid, tooltips, burger menu, image comparison slider, sticky table, theme switcher, loading animations and more
- document new CSS layout & styling demos in README and navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896113674bc8333a6f98f3ace737a23