### PR TITLE
Add accessibility and UX demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Open index.html for an interactive menu that previews each showcase.
 - [Responsive split-screen layout](split-screen-layout/)
 - [CSS floating labels for forms](floating-labels/)
 - [Glassmorphism UI effect](glassmorphism/)
+- [Skip to content link](skip-to-content/)
+- [High-contrast mode toggle](high-contrast-toggle/)
+- [Text size adjuster](text-size-adjuster/)
+- [Keyboard-only navigation demo](keyboard-only-navigation/)
+- [ARIA live region announcements](aria-live-region/)
+- [Voice commands using SpeechRecognition API](voice-commands/)
+- [Focus highlight for form elements](focus-highlight/)
+- [Accessible accordion component](accessible-accordion/)
+- [Accessible tabs with ARIA roles](accessible-tabs/)
+- [Read aloud selected text](read-aloud/)
 
 - [Webcam photo capture using getUserMedia API](webcam-photo-capture/)
 - [Video recording and playback in browser](video-recording/)
@@ -82,20 +92,8 @@ Open index.html for an interactive menu that previews each showcase.
 
 ## Planned Showcases
 
-### Accessibility & UX
-61. Skip to content link demo  
-62. High-contrast mode toggle  
-63. Text size adjuster  
-64. Keyboard-only navigation demo  
-65. ARIA live region announcements  
-66. Voice commands using SpeechRecognition API  
-67. Focus highlight for form elements  
-68. Accessible accordion component  
-69. Accessible tabs with ARIA roles  
-70. Read aloud selected text  
-
 ### Games & Fun
-71. Memory match card game  
+71. Memory match card game
 72. Tic-tac-toe game  
 73. Snake game  
 74. Whack-a-mole game  

--- a/accessible-accordion/index.html
+++ b/accessible-accordion/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Accessible Accordion</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="accordion">
+  <h3>
+    <button aria-expanded="false" class="accordion-trigger" aria-controls="sect1" id="accordion1">Section 1</button>
+  </h3>
+  <div id="sect1" role="region" aria-labelledby="accordion1" hidden>
+    <p>Content for section 1.</p>
+  </div>
+
+  <h3>
+    <button aria-expanded="false" class="accordion-trigger" aria-controls="sect2" id="accordion2">Section 2</button>
+  </h3>
+  <div id="sect2" role="region" aria-labelledby="accordion2" hidden>
+    <p>Content for section 2.</p>
+  </div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/accessible-accordion/script.js
+++ b/accessible-accordion/script.js
@@ -1,0 +1,9 @@
+const triggers = document.querySelectorAll('.accordion-trigger');
+triggers.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const expanded = btn.getAttribute('aria-expanded') === 'true';
+    btn.setAttribute('aria-expanded', !expanded);
+    const section = document.getElementById(btn.getAttribute('aria-controls'));
+    section.hidden = expanded;
+  });
+});

--- a/accessible-accordion/styles.css
+++ b/accessible-accordion/styles.css
@@ -1,0 +1,13 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+.accordion-trigger {
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+[hidden] {
+  display: none;
+}

--- a/accessible-tabs/index.html
+++ b/accessible-tabs/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Accessible Tabs</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="tabs" role="tablist">
+  <button role="tab" aria-selected="true" aria-controls="panel1" id="tab1">Tab 1</button>
+  <button role="tab" aria-selected="false" aria-controls="panel2" id="tab2" tabindex="-1">Tab 2</button>
+  <button role="tab" aria-selected="false" aria-controls="panel3" id="tab3" tabindex="-1">Tab 3</button>
+</div>
+<div id="panel1" role="tabpanel" aria-labelledby="tab1">
+  <p>Content for tab one.</p>
+</div>
+<div id="panel2" role="tabpanel" aria-labelledby="tab2" hidden>
+  <p>Content for tab two.</p>
+</div>
+<div id="panel3" role="tabpanel" aria-labelledby="tab3" hidden>
+  <p>Content for tab three.</p>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/accessible-tabs/script.js
+++ b/accessible-tabs/script.js
@@ -1,0 +1,26 @@
+const tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+const panels = Array.from(document.querySelectorAll('[role="tabpanel"]'));
+function activate(tab) {
+  tabs.forEach(t => {
+    const selected = t === tab;
+    t.setAttribute('aria-selected', selected);
+    t.tabIndex = selected ? 0 : -1;
+    const panel = document.getElementById(t.getAttribute('aria-controls'));
+    panel.hidden = !selected;
+  });
+}
+tabs.forEach(tab => {
+  tab.addEventListener('click', () => activate(tab));
+  tab.addEventListener('keydown', e => {
+    let idx = tabs.indexOf(document.activeElement);
+    if (e.key === 'ArrowRight') {
+      idx = (idx + 1) % tabs.length;
+      tabs[idx].focus();
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft') {
+      idx = (idx - 1 + tabs.length) % tabs.length;
+      tabs[idx].focus();
+      e.preventDefault();
+    }
+  });
+});

--- a/accessible-tabs/styles.css
+++ b/accessible-tabs/styles.css
@@ -1,0 +1,20 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+}
+[role="tab"] {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  background: #eee;
+}
+[role="tab"][aria-selected="true"] {
+  background: #fff;
+  border-bottom: 2px solid #000;
+}
+[role="tabpanel"] {
+  margin-top: 1rem;
+}

--- a/aria-live-region/index.html
+++ b/aria-live-region/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ARIA Live Region</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<button id="notify">Announce Message</button>
+<div id="live" aria-live="polite" class="live-region"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/aria-live-region/script.js
+++ b/aria-live-region/script.js
@@ -1,0 +1,7 @@
+const btn = document.getElementById('notify');
+const live = document.getElementById('live');
+let count = 0;
+btn.addEventListener('click', () => {
+  count++;
+  live.textContent = `Announcement ${count}`;
+});

--- a/aria-live-region/styles.css
+++ b/aria-live-region/styles.css
@@ -1,0 +1,8 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+.live-region {
+  margin-top: 1rem;
+  min-height: 1.5em;
+}

--- a/focus-highlight/index.html
+++ b/focus-highlight/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Focus Highlight</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<form>
+  <label>Name <input type="text"></label>
+  <label>Email <input type="email"></label>
+  <label>Message <textarea></textarea></label>
+  <button type="submit">Submit</button>
+</form>
+</body>
+</html>

--- a/focus-highlight/styles.css
+++ b/focus-highlight/styles.css
@@ -1,0 +1,16 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+input, textarea {
+  display: block;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border: 2px solid #ccc;
+  border-radius: 4px;
+}
+input:focus, textarea:focus {
+  border-color: #007BFF;
+  box-shadow: 0 0 3px #007BFF;
+  outline: none;
+}

--- a/high-contrast-toggle/index.html
+++ b/high-contrast-toggle/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>High Contrast Mode</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="contrast-toggle">Toggle High Contrast</button>
+  <h1>High Contrast Mode</h1>
+  <p>Toggle high contrast colors for better readability.</p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/high-contrast-toggle/script.js
+++ b/high-contrast-toggle/script.js
@@ -1,0 +1,4 @@
+const btn = document.getElementById('contrast-toggle');
+btn.addEventListener('click', () => {
+  document.body.classList.toggle('high-contrast');
+});

--- a/high-contrast-toggle/styles.css
+++ b/high-contrast-toggle/styles.css
@@ -1,0 +1,14 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+body.high-contrast {
+  background: #000;
+  color: #fff;
+}
+body.high-contrast a {
+  color: #0ff;
+}
+button {
+  margin-bottom: 1rem;
+}

--- a/keyboard-only-navigation/index.html
+++ b/keyboard-only-navigation/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Keyboard Navigation Demo</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<nav>
+  <ul id="menu">
+    <li><a href="#" tabindex="0">Home</a></li>
+    <li><a href="#" tabindex="0">Products</a></li>
+    <li><a href="#" tabindex="0">Contact</a></li>
+  </ul>
+</nav>
+<p>Use arrow keys to navigate the menu items.</p>
+<script src="script.js"></script>
+</body>
+</html>

--- a/keyboard-only-navigation/script.js
+++ b/keyboard-only-navigation/script.js
@@ -1,0 +1,15 @@
+const items = Array.from(document.querySelectorAll('#menu a'));
+items.forEach(a => {
+  a.addEventListener('keydown', e => {
+    let idx = items.indexOf(document.activeElement);
+    if (e.key === 'ArrowRight') {
+      idx = (idx + 1) % items.length;
+      items[idx].focus();
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft') {
+      idx = (idx - 1 + items.length) % items.length;
+      items[idx].focus();
+      e.preventDefault();
+    }
+  });
+});

--- a/keyboard-only-navigation/styles.css
+++ b/keyboard-only-navigation/styles.css
@@ -1,0 +1,13 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+#menu {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+}
+#menu a:focus {
+  outline: 2px solid blue;
+}

--- a/read-aloud/index.html
+++ b/read-aloud/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Read Aloud Selected Text</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<p>Select some text on this page and click the button to have it read aloud using SpeechSynthesis.</p>
+<button id="read">Read Selected Text</button>
+<script src="script.js"></script>
+</body>
+</html>

--- a/read-aloud/script.js
+++ b/read-aloud/script.js
@@ -1,0 +1,8 @@
+const btn = document.getElementById('read');
+btn.addEventListener('click', () => {
+  const text = window.getSelection().toString();
+  if (text) {
+    const utter = new SpeechSynthesisUtterance(text);
+    speechSynthesis.speak(utter);
+  }
+});

--- a/read-aloud/styles.css
+++ b/read-aloud/styles.css
@@ -1,0 +1,7 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+button {
+  margin-top: 1rem;
+}

--- a/skip-to-content/index.html
+++ b/skip-to-content/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Skip to Content Demo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <a href="#main" class="skip-link">Skip to content</a>
+  <nav>
+    <ul>
+      <li><a href="#">Home</a></li>
+      <li><a href="#">About</a></li>
+      <li><a href="#">Contact</a></li>
+    </ul>
+  </nav>
+  <main id="main" tabindex="-1">
+    <h1>Skip Link Example</h1>
+    <p>This page demonstrates a skip to content link for keyboard users.</p>
+  </main>
+</body>
+</html>

--- a/skip-to-content/styles.css
+++ b/skip-to-content/styles.css
@@ -1,0 +1,18 @@
+.skip-link {
+  position: absolute;
+  left: 0;
+  top: -40px;
+  background: #000;
+  color: #fff;
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.3s;
+}
+.skip-link:focus {
+  top: 0;
+}
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}

--- a/text-size-adjuster/index.html
+++ b/text-size-adjuster/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Text Size Adjuster</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="controls">
+    <button id="decrease">A-</button>
+    <button id="increase">A+</button>
+  </div>
+  <p id="content">Use the buttons to adjust text size for better readability.</p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/text-size-adjuster/script.js
+++ b/text-size-adjuster/script.js
@@ -1,0 +1,15 @@
+const inc = document.getElementById('increase');
+const dec = document.getElementById('decrease');
+let size = 100;
+function update(){
+  document.documentElement.style.fontSize = size + '%';
+}
+inc.addEventListener('click', () => {
+  size += 10;
+  update();
+});
+dec.addEventListener('click', () => {
+  if (size > 50) size -= 10;
+  update();
+});
+update();

--- a/text-size-adjuster/styles.css
+++ b/text-size-adjuster/styles.css
@@ -1,0 +1,7 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+.controls {
+  margin-bottom: 1rem;
+}

--- a/voice-commands/index.html
+++ b/voice-commands/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Voice Commands</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<button id="start">Start Listening</button>
+<p id="status">Say "red", "green", or "blue" to change background.</p>
+<script src="script.js"></script>
+</body>
+</html>

--- a/voice-commands/script.js
+++ b/voice-commands/script.js
@@ -1,0 +1,22 @@
+const startBtn = document.getElementById('start');
+const status = document.getElementById('status');
+let recognition;
+if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  recognition = new SpeechRecognition();
+  recognition.lang = 'en-US';
+  recognition.onresult = e => {
+    const transcript = e.results[0][0].transcript.toLowerCase();
+    status.textContent = 'Heard: ' + transcript;
+    if (['red','green','blue','yellow','white'].includes(transcript)) {
+      document.body.style.background = transcript;
+    }
+  };
+  recognition.onerror = e => {
+    status.textContent = 'Error: ' + e.error;
+  };
+} else {
+  startBtn.disabled = true;
+  status.textContent = 'SpeechRecognition not supported in this browser.';
+}
+startBtn.addEventListener('click', () => recognition && recognition.start());

--- a/voice-commands/styles.css
+++ b/voice-commands/styles.css
@@ -1,0 +1,8 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+  transition: background 0.3s;
+}
+button {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- showcase skip links, high contrast toggle, and text resizing
- add keyboard navigation, live region announcements, and voice commands
- include focus highlights, accordion, tabs, and read-aloud utilities

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689618dfd1148333bdefee84f596c70b