### PR TITLE
Add classic games showcases

### DIFF
--- a/2048/index.html
+++ b/2048/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>2048</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="board"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/2048/script.js
+++ b/2048/script.js
@@ -1,0 +1,45 @@
+const boardEl = document.getElementById('board');
+let board = Array(4).fill().map(()=>Array(4).fill(0));
+
+document.addEventListener('keydown', e => {
+  let moved = false;
+  if (['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.key)) {
+    for (let i=0;i<4;i++) {
+      let row = board[i];
+      if (e.key==='ArrowUp' || e.key==='ArrowDown') row = board.map(r=>r[i]);
+      if (e.key==='ArrowRight' || e.key==='ArrowDown') row.reverse();
+      const filtered = row.filter(v=>v);
+      for (let j=0;j<filtered.length-1;j++) {
+        if (filtered[j]===filtered[j+1]) { filtered[j]*=2; filtered.splice(j+1,1); }
+      }
+      while (filtered.length<4) filtered.push(0);
+      if (e.key==='ArrowRight' || e.key==='ArrowDown') filtered.reverse();
+      if (e.key==='ArrowUp' || e.key==='ArrowDown') filtered.forEach((v,j)=>board[j][i]=v);
+      else board[i] = filtered;
+      moved = moved || row.toString() !== filtered.toString();
+    }
+    if (moved) addTile();
+    draw();
+  }
+});
+
+function addTile() {
+  const empty = [];
+  board.forEach((row,i)=>row.forEach((v,j)=>{ if(!v) empty.push([i,j]); }));
+  const [i,j] = empty[Math.floor(Math.random()*empty.length)];
+  board[i][j] = Math.random()<0.9?2:4;
+}
+
+function draw() {
+  boardEl.innerHTML='';
+  board.flat().forEach(v=>{
+    const div = document.createElement('div');
+    div.className='tile';
+    div.textContent = v||'';
+    boardEl.appendChild(div);
+  });
+}
+
+addTile();
+addTile();
+draw();

--- a/2048/styles.css
+++ b/2048/styles.css
@@ -1,0 +1,20 @@
+#board {
+  width: 260px;
+  height: 260px;
+  background: #bbada0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  padding: 10px;
+  margin: 40px auto;
+  box-sizing: border-box;
+}
+.tile {
+  background: #cdc1b4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: bold;
+  height: 60px;
+}

--- a/README.md
+++ b/README.md
@@ -89,24 +89,22 @@ Open index.html for an interactive menu that previews each showcase.
 - [Detect online/offline status](online-status/)
 - [Text-to-Morse code translator](text-to-morse/)
 - [Browser history API demo](history-api/)
+- [Memory match card game](memory-match/)
+- [Tic-tac-toe game](tic-tac-toe/)
+- [Snake game](snake-game/)
+- [Whack-a-mole game](whack-a-mole/)
+- [2048 game clone](2048/)
+- [Simon Says color memory game](simon-says/)
+- [Rock-paper-scissors with animations](rock-paper-scissors/)
+- [Hangman word guessing game](hangman/)
+- [Sliding puzzle game](sliding-puzzle/)
+- [Pong game clone](pong/)
 
 ## Planned Showcases
 
-### Games & Fun
-71. Memory match card game
-72. Tic-tac-toe game  
-73. Snake game  
-74. Whack-a-mole game  
-75. 2048 game clone  
-76. Simon Says color memory game  
-77. Rock-paper-scissors with animations  
-78. Hangman word guessing game  
-79. Sliding puzzle game  
-80. Pong game clone  
-
 ### Browser & Device APIs
-81. Vibration API demo for mobile  
-82. Battery status API viewer  
+81. Vibration API demo for mobile
+82. Battery status API viewer
 83. Device orientation & motion tracking  
 84. Ambient light sensor demo  
 85. Bluetooth device connection demo  

--- a/hangman/index.html
+++ b/hangman/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hangman</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <p id="word"></p>
+  <p>Wrong: <span id="wrong"></span></p>
+  <div id="letters"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/hangman/script.js
+++ b/hangman/script.js
@@ -1,0 +1,29 @@
+const words = ['javascript','browser','hangman','coding'];
+const word = words[Math.floor(Math.random()*words.length)];
+const display = Array(word.length).fill('_');
+const wordEl = document.getElementById('word');
+const wrongEl = document.getElementById('wrong');
+const lettersEl = document.getElementById('letters');
+let wrong = [];
+
+wordEl.textContent = display.join(' ');
+
+'abcdefghijklmnopqrstuvwxyz'.split('').forEach(ch=>{
+  const btn = document.createElement('button');
+  btn.textContent = ch;
+  btn.addEventListener('click', ()=>guess(ch, btn));
+  lettersEl.appendChild(btn);
+});
+
+function guess(ch, btn) {
+  btn.disabled = true;
+  if (word.includes(ch)) {
+    [...word].forEach((c,i)=>{ if (c===ch) display[i]=ch; });
+    wordEl.textContent = display.join(' ');
+    if (!display.includes('_')) alert('You win!');
+  } else {
+    wrong.push(ch);
+    wrongEl.textContent = wrong.join(' ');
+    if (wrong.length >= 6) { alert('Game over'); }
+  }
+}

--- a/hangman/styles.css
+++ b/hangman/styles.css
@@ -1,0 +1,3 @@
+body { text-align: center; font-family: sans-serif; }
+#letters button { margin: 2px; }
+#word { font-size: 24px; letter-spacing: 4px; }

--- a/memory-match/index.html
+++ b/memory-match/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Memory Match</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="game"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/memory-match/script.js
+++ b/memory-match/script.js
@@ -1,0 +1,39 @@
+const symbols = ['🍎','🍌','🍇','🍒','🥝','🍑','🍋','🍉'];
+let cards = [...symbols, ...symbols].sort(() => Math.random() - 0.5);
+const game = document.getElementById('game');
+let first = null;
+let lock = false;
+
+cards.forEach(sym => {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.dataset.sym = sym;
+  div.addEventListener('click', flip);
+  game.appendChild(div);
+});
+
+function flip() {
+  if (lock || this.classList.contains('matched') || this === first) return;
+  this.textContent = this.dataset.sym;
+  this.classList.add('flipped');
+  if (!first) { first = this; return; }
+  lock = true;
+  if (first.dataset.sym === this.dataset.sym) {
+    first.classList.add('matched');
+    this.classList.add('matched');
+    reset();
+  } else {
+    setTimeout(() => {
+      first.textContent = '';
+      this.textContent = '';
+      first.classList.remove('flipped');
+      this.classList.remove('flipped');
+      reset();
+    }, 800);
+  }
+}
+
+function reset() {
+  first = null;
+  lock = false;
+}

--- a/memory-match/styles.css
+++ b/memory-match/styles.css
@@ -1,0 +1,23 @@
+#game {
+  display: grid;
+  grid-template-columns: repeat(4, 80px);
+  gap: 10px;
+  justify-content: center;
+  margin-top: 50px;
+}
+.card {
+  width: 80px;
+  height: 80px;
+  background: #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 40px;
+  cursor: pointer;
+}
+.card.flipped {
+  background: #fff;
+}
+.card.matched {
+  background: #8f8;
+}

--- a/pong/index.html
+++ b/pong/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pong</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <canvas id="game" width="400" height="300"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/pong/script.js
+++ b/pong/script.js
@@ -1,0 +1,32 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const paddleH=60,paddleW=10;
+let playerY = canvas.height/2 - paddleH/2;
+let cpuY = playerY;
+let ball = {x:canvas.width/2, y:canvas.height/2, vx:3, vy:3};
+
+function draw() {
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  ctx.fillStyle='white';
+  ctx.fillRect(0, playerY, paddleW, paddleH);
+  ctx.fillRect(canvas.width-paddleW, cpuY, paddleW, paddleH);
+  ctx.beginPath();
+  ctx.arc(ball.x, ball.y, 5, 0, Math.PI*2);
+  ctx.fill();
+}
+
+function update() {
+  ball.x += ball.vx; ball.y += ball.vy;
+  if (ball.y<0||ball.y>canvas.height) ball.vy*=-1;
+  if (ball.x< paddleW && ball.y>playerY && ball.y<playerY+paddleH) ball.vx*=-1;
+  if (ball.x> canvas.width-paddleW && ball.y>cpuY && ball.y<cpuY+paddleH) ball.vx*=-1;
+  if (ball.x<0||ball.x>canvas.width) reset();
+  cpuY += (ball.y - (cpuY+paddleH/2))*0.05;
+}
+
+function reset(){ ball={x:canvas.width/2,y:canvas.height/2,vx:3*(Math.random()>0.5?1:-1),vy:3*(Math.random()>0.5?1:-1)}; }
+
+canvas.addEventListener('mousemove', e=>{ playerY = e.offsetY - paddleH/2; });
+
+function loop(){ update(); draw(); requestAnimationFrame(loop); }
+loop();

--- a/pong/styles.css
+++ b/pong/styles.css
@@ -1,0 +1,2 @@
+body { display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+canvas { background: #000; }

--- a/rock-paper-scissors/index.html
+++ b/rock-paper-scissors/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rock Paper Scissors</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="choices">
+    <button data-choice="rock">✊</button>
+    <button data-choice="paper">✋</button>
+    <button data-choice="scissors">✌️</button>
+  </div>
+  <p id="result"></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/rock-paper-scissors/script.js
+++ b/rock-paper-scissors/script.js
@@ -1,0 +1,12 @@
+const result = document.getElementById('result');
+const choices = ['rock','paper','scissors'];
+
+document.querySelectorAll('#choices button').forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const player = btn.dataset.choice;
+    const cpu = choices[Math.floor(Math.random()*3)];
+    const win = (player==='rock'&&cpu==='scissors')||(player==='paper'&&cpu==='rock')||(player==='scissors'&&cpu==='paper');
+    const tie = player===cpu;
+    result.textContent = `You ${tie?'tie':' '+(win?'win':'lose')}! CPU chose ${cpu}.`;
+  });
+});

--- a/rock-paper-scissors/styles.css
+++ b/rock-paper-scissors/styles.css
@@ -1,0 +1,4 @@
+#choices { display: flex; gap: 10px; justify-content: center; margin-top: 40px; }
+button { font-size: 40px; padding: 10px; cursor: pointer; transition: transform 0.2s; }
+button:hover { transform: scale(1.2); }
+#result { text-align: center; margin-top: 20px; font-size: 20px; }

--- a/simon-says/index.html
+++ b/simon-says/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Simon Says</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="board">
+    <div class="pad" id="green"></div>
+    <div class="pad" id="red"></div>
+    <div class="pad" id="yellow"></div>
+    <div class="pad" id="blue"></div>
+  </div>
+  <button id="start">Start</button>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/simon-says/script.js
+++ b/simon-says/script.js
@@ -1,0 +1,36 @@
+const pads = ['green','red','yellow','blue'].map(id=>document.getElementById(id));
+const startBtn = document.getElementById('start');
+let sequence=[], userSeq=[];
+
+function flash(pad) {
+  pad.classList.add('active');
+  setTimeout(()=>pad.classList.remove('active'), 400);
+}
+
+function playSeq() {
+  let i=0;
+  const interval = setInterval(()=>{
+    flash(pads[sequence[i]]);
+    i++;
+    if (i>=sequence.length) clearInterval(interval);
+  },600);
+}
+
+pads.forEach((pad,i)=>pad.addEventListener('click', ()=>{
+  userSeq.push(i);
+  flash(pad);
+  if (sequence[userSeq.length-1] !== i) {
+    alert('Wrong!');
+    userSeq=[]; sequence=[];
+  } else if (userSeq.length === sequence.length) {
+    userSeq=[];
+    sequence.push(Math.floor(Math.random()*4));
+    setTimeout(playSeq, 1000);
+  }
+}));
+
+startBtn.addEventListener('click', ()=>{
+  sequence=[Math.floor(Math.random()*4)];
+  userSeq=[];
+  playSeq();
+});

--- a/simon-says/styles.css
+++ b/simon-says/styles.css
@@ -1,0 +1,19 @@
+#board {
+  width: 200px;
+  height: 200px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  margin: 20px auto;
+}
+.pad {
+  width: 90px;
+  height: 90px;
+  opacity: 0.6;
+  cursor: pointer;
+}
+#green { background: green; }
+#red { background: red; }
+#yellow { background: yellow; }
+#blue { background: blue; }
+.pad.active { opacity: 1; }

--- a/sliding-puzzle/index.html
+++ b/sliding-puzzle/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sliding Puzzle</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="puzzle"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/sliding-puzzle/script.js
+++ b/sliding-puzzle/script.js
@@ -1,0 +1,34 @@
+const puzzle = document.getElementById('puzzle');
+let tiles = [...Array(8).keys()].map(n=>n+1).concat(0);
+shuffle(tiles);
+render();
+
+function shuffle(arr) {
+  for (let i=arr.length-1;i>0;i--) {
+    const j=Math.floor(Math.random()*(i+1));
+    [arr[i],arr[j]]=[arr[j],arr[i]];
+  }
+}
+
+function render() {
+  puzzle.innerHTML='';
+  tiles.forEach((n,i)=>{
+    const div=document.createElement('div');
+    div.className='tile'+(n===0?' empty':'');
+    div.textContent = n||'';
+    div.addEventListener('click',()=>move(i));
+    puzzle.appendChild(div);
+  });
+}
+
+function move(i) {
+  const emptyIndex = tiles.indexOf(0);
+  const valid = [emptyIndex-3, emptyIndex+3];
+  if (emptyIndex%3!==0) valid.push(emptyIndex-1);
+  if (emptyIndex%3!==2) valid.push(emptyIndex+1);
+  if (valid.includes(i)) {
+    [tiles[i], tiles[emptyIndex]] = [tiles[emptyIndex], tiles[i]];
+    render();
+    if (tiles.join('')==='123456780') alert('Solved!');
+  }
+}

--- a/sliding-puzzle/styles.css
+++ b/sliding-puzzle/styles.css
@@ -1,0 +1,17 @@
+#puzzle {
+  width: 240px;
+  height: 240px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+  margin: 40px auto;
+}
+.tile {
+  background: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  cursor: pointer;
+}
+.empty { background: transparent; cursor: default; }

--- a/snake-game/index.html
+++ b/snake-game/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Snake</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <canvas id="game" width="200" height="200"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/snake-game/script.js
+++ b/snake-game/script.js
@@ -1,0 +1,39 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const grid = 20;
+let snake = [{x:160,y:160}];
+let dx = grid, dy = 0;
+let apple = randomPosition();
+let loop;
+
+function randomPosition() {
+  return { x: Math.floor(Math.random()*10)*grid, y: Math.floor(Math.random()*10)*grid };
+}
+
+function game() {
+  loop = setTimeout(game, 100);
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  snake.unshift({x: snake[0].x + dx, y: snake[0].y + dy});
+  if (snake[0].x === apple.x && snake[0].y === apple.y) {
+    apple = randomPosition();
+  } else {
+    snake.pop();
+  }
+  ctx.fillStyle = 'red';
+  ctx.fillRect(apple.x, apple.y, grid-1, grid-1);
+  ctx.fillStyle = 'lime';
+  snake.forEach(part => ctx.fillRect(part.x, part.y, grid-1, grid-1));
+  if (snake[0].x<0 || snake[0].x>=canvas.width || snake[0].y<0 || snake[0].y>=canvas.height || snake.slice(1).some(p=>p.x===snake[0].x&&p.y===snake[0].y)) {
+    clearTimeout(loop);
+    alert('Game over');
+  }
+}
+
+document.addEventListener('keydown', e => {
+  if (e.key==='ArrowLeft' && dx===0) {dx=-grid;dy=0;}
+  if (e.key==='ArrowRight' && dx===0) {dx=grid;dy=0;}
+  if (e.key==='ArrowUp' && dy===0) {dy=-grid;dx=0;}
+  if (e.key==='ArrowDown' && dy===0) {dy=grid;dx=0;}
+});
+
+game();

--- a/snake-game/styles.css
+++ b/snake-game/styles.css
@@ -1,0 +1,2 @@
+body { display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+canvas { background: #000; }

--- a/tic-tac-toe/index.html
+++ b/tic-tac-toe/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tic Tac Toe</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="board"></div>
+  <p id="status"></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/tic-tac-toe/script.js
+++ b/tic-tac-toe/script.js
@@ -1,0 +1,31 @@
+const board = document.getElementById('board');
+const status = document.getElementById('status');
+let cells = Array(9).fill(null);
+let current = 'X';
+
+cells.forEach((_, i) => {
+  const div = document.createElement('div');
+  div.className = 'cell';
+  div.addEventListener('click', () => move(i));
+  board.appendChild(div);
+});
+
+function move(i) {
+  if (cells[i] || winner()) return;
+  cells[i] = current;
+  board.children[i].textContent = current;
+  if (winner()) status.textContent = `${current} wins!`;
+  else if (cells.every(Boolean)) status.textContent = 'Draw';
+  else current = current === 'X' ? 'O' : 'X';
+}
+
+function winner() {
+  const wins = [
+    [0,1,2],[3,4,5],[6,7,8],
+    [0,3,6],[1,4,7],[2,5,8],
+    [0,4,8],[2,4,6]
+  ];
+  return wins.some(pattern =>
+    pattern.every(i => cells[i] && cells[i] === cells[pattern[0]])
+  );
+}

--- a/tic-tac-toe/styles.css
+++ b/tic-tac-toe/styles.css
@@ -1,0 +1,16 @@
+#board {
+  display: grid;
+  grid-template-columns: repeat(3, 80px);
+  gap: 5px;
+  margin: 40px auto;
+}
+.cell {
+  width: 80px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 40px;
+  background: #eee;
+  cursor: pointer;
+}

--- a/whack-a-mole/index.html
+++ b/whack-a-mole/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Whack a Mole</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="start">Start</button>
+  <div id="grid"></div>
+  <p>Score: <span id="score">0</span></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/whack-a-mole/script.js
+++ b/whack-a-mole/script.js
@@ -1,0 +1,31 @@
+const grid = document.getElementById('grid');
+const scoreEl = document.getElementById('score');
+const startBtn = document.getElementById('start');
+let score = 0;
+let timer;
+
+for (let i=0;i<9;i++) {
+  const div = document.createElement('div');
+  div.className='hole';
+  div.addEventListener('click', () => {
+    if (div.classList.contains('mole')) {
+      score++;
+      scoreEl.textContent = score;
+      div.classList.remove('mole');
+    }
+  });
+  grid.appendChild(div);
+}
+
+function start() {
+  score = 0; scoreEl.textContent = 0;
+  clearInterval(timer);
+  timer = setInterval(() => {
+    grid.querySelectorAll('.mole').forEach(h=>h.classList.remove('mole'));
+    const hole = grid.children[Math.floor(Math.random()*9)];
+    hole.classList.add('mole');
+  }, 800);
+  setTimeout(()=>{clearInterval(timer); alert('Time up!');}, 10000);
+}
+
+startBtn.addEventListener('click', start);

--- a/whack-a-mole/styles.css
+++ b/whack-a-mole/styles.css
@@ -1,0 +1,19 @@
+#grid {
+  display: grid;
+  grid-template-columns: repeat(3, 80px);
+  gap: 10px;
+  margin: 20px 0;
+}
+.hole {
+  width: 80px;
+  height: 80px;
+  background: #cfc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 40px;
+  cursor: pointer;
+}
+.mole {
+  background: #f88;
+}


### PR DESCRIPTION
## Summary
- add interactive memory match, tic-tac-toe, snake, whack-a-mole, 2048, Simon Says, rock-paper-scissors, hangman, sliding puzzle, and pong examples
- link new games from README and remove them from the planned list

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68961b4f70b08333ad2a2c5ae0e1c6f6